### PR TITLE
Fix CSS typo

### DIFF
--- a/assets/css/story.css
+++ b/assets/css/story.css
@@ -64,7 +64,7 @@
   line-height: 1.5;
   overflow-y:  auto;
   max-height:  90%;
-  mas-width: 100%;
+  max-width: 100%;
   text-align:  center;
   width:       auto;
   height:      auto;


### PR DESCRIPTION
## Summary
- fix typo in story CSS: `max-width` was misspelled `mas-width`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6880758d5bb0832ebf4d5852fff74cf4