### PR TITLE
Fix flipbook layout on mobile

### DIFF
--- a/assets/css/story.css
+++ b/assets/css/story.css
@@ -102,12 +102,13 @@
   #flipbook {
     width:  98vw;
     max-width: 100vw;
-    flex-direction: column;
-    height: auto;
+    /* keep pages side-by-side on small screens */
+    flex-direction: row;
+    height: calc(98vw * 0.66);
   }
   #flipbook .page{
      border-radius: var(--card-radius);
-     margin-bottom: 1rem;
+     margin-bottom: 0;
   }
   .text-page { padding: 1rem; }
   .image-page{ padding: 0.5rem; }


### PR DESCRIPTION
## Summary
- ensure the flipbook stays in a two-page spread on small screens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68807a50b410832e8418402829c6c240