### PR TITLE
Fix modal overlay z-index for Wedding Party page

### DIFF
--- a/assets/css/wedding-party.css
+++ b/assets/css/wedding-party.css
@@ -64,7 +64,8 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  z-index: 999;
+  /* ensure the overlay appears above the sticky header */
+  z-index: 1100;
 }
 .modal-overlay.hidden {
   display: none;


### PR DESCRIPTION
## Summary
- ensure the modal overlay appears above the sticky header on small screens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688080b5a5ac832e8e7a7af8796a837f