### PR TITLE
Add themed flip-clock

### DIFF
--- a/assets/css/flipclock.css
+++ b/assets/css/flipclock.css
@@ -1,0 +1,99 @@
+/* Flip clock countdown styles */
+.flip-clock {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 8px;
+  perspective: 300px;
+}
+
+.flip-digit {
+  position: relative;
+  width: 40px;
+  height: 60px;
+  background: var(--white);
+  border-radius: 6px;
+  border: 2px solid var(--emerald-border);
+  color: var(--emerald-border);
+  font-family: var(--font-display);
+  font-size: 2rem;
+  overflow: hidden;
+}
+
+.flip-digit span {
+  position: absolute;
+  left: 0;
+  width: 100%;
+  height: 50%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  backface-visibility: hidden;
+}
+
+.flip-digit .top {
+  top: 0;
+  border-bottom: 1px solid var(--emerald-border);
+  transform-origin: bottom;
+}
+
+.flip-digit .bottom {
+  bottom: 0;
+  border-top: 1px solid var(--emerald-border);
+  transform: rotateX(180deg);
+  transform-origin: top;
+}
+
+.flip-digit .top-flip {
+  top: 0;
+  border-bottom: 1px solid var(--emerald-border);
+  transform-origin: bottom;
+  animation: flipTop 0.5s forwards;
+}
+
+.flip-digit .bottom-flip {
+  bottom: 0;
+  border-top: 1px solid var(--emerald-border);
+  transform-origin: top;
+  animation: flipBottom 0.5s forwards;
+}
+
+.separator {
+  font-family: var(--font-display);
+  font-size: 2.2rem;
+  line-height: 60px;
+  color: var(--emerald-border);
+}
+
+@keyframes flipTop {
+  0% { transform: rotateX(0); }
+  100% { transform: rotateX(-90deg); }
+}
+
+@keyframes flipBottom {
+  0% { transform: rotateX(90deg); }
+  100% { transform: rotateX(0); }
+}
+
+/* Size modifiers */
+.flip-clock.flip-small .flip-digit {
+  width: 32px;
+  height: 48px;
+  font-size: 1.6rem;
+}
+
+.flip-clock.flip-small .separator {
+  font-size: 1.8rem;
+  line-height: 48px;
+}
+
+.flip-clock.flip-large .flip-digit {
+  width: 60px;
+  height: 90px;
+  font-size: 3rem;
+}
+
+.flip-clock.flip-large .separator {
+  font-size: 3.2rem;
+  line-height: 90px;
+}

--- a/assets/css/home.css
+++ b/assets/css/home.css
@@ -21,14 +21,6 @@
   .big-rsvp-btn { font-size:1rem; padding:.7rem 2rem; }
 }
 
-.countdown-ticker {
-  font-size: 3rem;
-  font-weight: bold;
-  color: white;
-  margin-bottom: 40px;
-  text-align: center;
-  letter-spacing: 2px;
-}
 
 .home-update-box {
   background: #fff;

--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -131,11 +131,3 @@
   }
 }
 
-/* Countdown ticker under the date */
-.countdown {
-  font-family: var(--font-display);
-  font-size: 1.1rem;
-  color: var(--emerald-accent);
-  margin-top: 0.8rem;
-  letter-spacing: 0.04em;
-}

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -33,27 +33,84 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   }
 
-  // ── 3) Countdown ticker (wherever #countdown exists) ──
+  // ── 3) Countdown ticker (flip clock) ──
   const countdownEl = document.getElementById('countdown');
   if (countdownEl) {
     const target = new Date('2026-09-12T00:00:00');
-    let timer; // declared here so clearInterval(timer) works
+    const digits = [];
+    let timer;
 
-    function updateCountdown() {
-      const diff = target - Date.now();
-      if (diff <= 0) {
-        countdownEl.textContent = "It's today!";
-        clearInterval(timer);
-        return;
-      }
-      const days    = Math.floor(diff / (1000 * 60 * 60 * 24));
-      const hours   = Math.floor((diff / (1000 * 60 * 60)) % 24);
-      const minutes = Math.floor((diff / (1000 * 60)) % 60);
-      const seconds = Math.floor((diff / 1000) % 60);
-      countdownEl.textContent = `${days}d ${hours}h ${minutes}m ${seconds}s`;
+    function createDigit() {
+      const d = document.createElement('div');
+      d.className = 'flip-digit';
+      d.innerHTML = '<span class="top">0</span><span class="bottom">0</span>';
+      return d;
     }
 
-    updateCountdown();
-    timer = setInterval(updateCountdown, 1000);
+    function setupClock() {
+      countdownEl.classList.add('flip-clock');
+      const total = 3 + 2 + 2 + 2; // days, hours, minutes, seconds
+      for (let i = 0; i < total; i++) {
+        const digit = createDigit();
+        digits.push(digit);
+        countdownEl.appendChild(digit);
+        if (i === 2 || i === 4 || i === 6) {
+          const sep = document.createElement('span');
+          sep.className = 'separator';
+          sep.textContent = ':';
+          countdownEl.appendChild(sep);
+        }
+      }
+    }
+
+    function flipTo(digitEl, newNumber) {
+      const top = digitEl.querySelector('.top');
+      const bottom = digitEl.querySelector('.bottom');
+      if (top.textContent === newNumber) return;
+
+      const topFlip = document.createElement('span');
+      topFlip.className = 'top-flip';
+      topFlip.textContent = top.textContent;
+
+      const bottomFlip = document.createElement('span');
+      bottomFlip.className = 'bottom-flip';
+      bottomFlip.textContent = newNumber;
+
+      digitEl.appendChild(topFlip);
+      digitEl.appendChild(bottomFlip);
+
+      top.textContent = newNumber;
+      bottom.textContent = newNumber;
+
+      topFlip.addEventListener('animationend', () => topFlip.remove());
+      bottomFlip.addEventListener('animationend', () => bottomFlip.remove());
+    }
+
+    function updateClock() {
+      const diff = target - Date.now();
+      if (diff <= 0) {
+        clearInterval(timer);
+        countdownEl.innerHTML = "It's today!";
+        return;
+      }
+      const days = Math.floor(diff / (1000 * 60 * 60 * 24));
+      const hours = Math.floor((diff / (1000 * 60 * 60)) % 24);
+      const minutes = Math.floor((diff / (1000 * 60)) % 60);
+      const seconds = Math.floor((diff / 1000) % 60);
+
+      const str =
+        days.toString().padStart(3, '0') +
+        hours.toString().padStart(2, '0') +
+        minutes.toString().padStart(2, '0') +
+        seconds.toString().padStart(2, '0');
+
+      str.split('').forEach((num, idx) => {
+        flipTo(digits[idx], num);
+      });
+    }
+
+    setupClock();
+    updateClock();
+    timer = setInterval(updateClock, 1000);
   }
 });

--- a/home.html
+++ b/home.html
@@ -11,6 +11,7 @@
 
   <link rel="stylesheet" href="assets/css/theme.css">
 <link rel="stylesheet" href="assets/css/style.css">
+<link rel="stylesheet" href="assets/css/flipclock.css">
 <!-- then, only on that page: -->
 <link rel="stylesheet" href="assets/css/home.css">
   <!-- 3. Heading font -->
@@ -37,9 +38,7 @@
     </nav>
   </header>
   
-    <div id="countdown" class="countdown-ticker">
-      <!-- Countdown numbers go here, e.g. "10 Days 5 Hours 12 Minutes" -->
-    </div>
+    <div id="countdown" class="flip-clock flip-large"></div>
   <main class="content-container">
   <h1>Welcome Family & Friends</h1>  
     <p>Welcome to our wedding website! We are so excited to share this next chapter of our love story with you. 

--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
 
   <link rel="stylesheet" href="assets/css/theme.css">
   <link rel="stylesheet" href="assets/css/style.css">
+  <link rel="stylesheet" href="assets/css/flipclock.css">
   <link rel="stylesheet" href="assets/css/index.css">
 
   <link
@@ -44,7 +45,7 @@
         September 12, 2026&nbsp;•&nbsp;Portola, CA
       </div>
       <!-- ⬇ New countdown ticker -->
-    <div id="countdown" class="countdown"></div>
+    <div id="countdown" class="flip-clock flip-small"></div>
     </a>
   </div>
 


### PR DESCRIPTION
## Summary
- refine flip-clock visuals to match site theme
- add size modifiers so digits fit on index and home pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6880863a7604832e93fb1ec38ca77245