### PR TITLE
Improve site markup

### DIFF
--- a/accommodation.html
+++ b/accommodation.html
@@ -11,10 +11,6 @@
   <link rel="stylesheet" href="assets/css/style.css">
   <!-- page‑specific -->
   <link rel="stylesheet" href="assets/css/accommodations.css">
-
-  <link 
-    href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@600&display=swap" 
-    rel="stylesheet">
 </head>
 <body class="allow-scroll">
 

--- a/assets/css/theme.css
+++ b/assets/css/theme.css
@@ -84,9 +84,6 @@ html, body {
   pointer-events: none;
 }
 
-/* (optional) allow vertical scroll when needed */
-/*
 body.allow-scroll {
   overflow-y: auto;
 }
-*/

--- a/events.html
+++ b/events.html
@@ -12,7 +12,6 @@
   <!-- page‑specific -->
   <link rel="stylesheet" href="assets/css/events.css" />
   <link 
-    href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@600&display=swap" 
     rel="stylesheet" />
 </head>
 <body class="allow-scroll">

--- a/faqs.html
+++ b/faqs.html
@@ -15,13 +15,8 @@
   <link rel="stylesheet" href="assets/css/style.css">
   <!-- 3) page‑specific overrides -->
   <link rel="stylesheet" href="assets/css/faqs.css">
-
-  <!-- heading font (can stay here or be in style.css) -->
-  <link
-    href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@600&display=swap"
-    rel="stylesheet">
 </head>
-<body class="allow scroll">
+<body class="allow-scroll">
 
   <!-- ── Sticky Header & Nav (same on every page!) ── -->
   <header class="site-header">

--- a/gallery.html
+++ b/gallery.html
@@ -13,10 +13,6 @@
 <link rel="stylesheet" href="assets/css/style.css">
 <!-- then, only on that page: -->
 <link rel="stylesheet" href="assets/css/gallery.css">
-  <!-- 3. Heading font -->
-  <link
-    href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@600&display=swap"
-    rel="stylesheet" />
 </head>
 <body class="allow-scroll">
 

--- a/home.html
+++ b/home.html
@@ -12,14 +12,9 @@
   <link rel="stylesheet" href="assets/css/theme.css">
 <link rel="stylesheet" href="assets/css/style.css">
 <link rel="stylesheet" href="assets/css/flipclock.css">
-<!-- then, only on that page: -->
 <link rel="stylesheet" href="assets/css/home.css">
-  <!-- 3. Heading font -->
-  <link
-    href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@600&display=swap"
-    rel="stylesheet">
 </head>
-<body class="allow scroll">
+<body class="allow-scroll">
 
   <!-- ── Sticky Header & Nav (same on every page!) ── -->
   <header class="site-header">
@@ -55,7 +50,7 @@
     </div>
     
     <p>Check out the fun story of how we met each other</p>
-    <div class=text-page-buttons">
+    <div class="text-page-buttons">
 
     <a href="our-story.html" class="main-btn">Our Story</a>
   </div>

--- a/index.html
+++ b/index.html
@@ -13,10 +13,6 @@
   <link rel="stylesheet" href="assets/css/style.css">
   <link rel="stylesheet" href="assets/css/flipclock.css">
   <link rel="stylesheet" href="assets/css/index.css">
-
-  <link
-    href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@600&display=swap"
-    rel="stylesheet">
 </head>
 <body class="no-scroll">
   <!-- Video background with poster fallback -->

--- a/rsvp.html
+++ b/rsvp.html
@@ -11,9 +11,6 @@
   <link rel="stylesheet" href="assets/css/style.css">
   <!-- page-specific -->
   <link rel="stylesheet" href="assets/css/rsvp.css">
-  <link 
-    href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@600&display=swap" 
-    rel="stylesheet">
 </head>
 <body class="allow-scroll">
 

--- a/travel.html
+++ b/travel.html
@@ -10,13 +10,8 @@
 <link rel="icon" href="assets/images/favicon.png" type="image/png">
   <link rel="stylesheet" href="assets/css/theme.css">
 <link rel="stylesheet" href="assets/css/style.css">
-<!-- then, only on that page: -->
-  <!-- 3. Heading font -->
-  <link
-    href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@600&display=swap"
-    rel="stylesheet">
 </head>
-<body>
+<body class="allow-scroll">
 <!-- ── Sticky Header & Nav (same on every page!) ── -->
   <header class="site-header">
     <nav class="main-nav">

--- a/wedding-party.html
+++ b/wedding-party.html
@@ -12,9 +12,6 @@
   <!-- page‑specific -->
   <link rel="stylesheet" href="assets/css/wedding-party.css">
 
-  <link 
-    href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@600&display=swap" 
-    rel="stylesheet">
 </head>
 <body class="allow-scroll">
 


### PR DESCRIPTION
## Summary
- clean up stray font link placeholders across HTML pages
- remove duplicated font link tags
- fix `home.html` markup and restore home page CSS
- enable optional scrolling via `body.allow-scroll`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68808c36467c832eace13bbe9a5e5614