### PR TITLE
Remove RSVP heading

### DIFF
--- a/rsvp.html
+++ b/rsvp.html
@@ -36,9 +36,6 @@
 
   <!-- ── Content Card ── -->
   <main class="content-container">
-    <h1>RSVP</h1>
-    <p>Please use the form below to let us know you’re coming. We can’t wait to celebrate with you!</p>
-
     <div class="iframe-container">
       <iframe
         src="https://www.aisleplanner.com/app/v2/our-wedding/lcwedding/rsvp"


### PR DESCRIPTION
## Summary
- remove the header text from the RSVP page so only the form iframe is shown

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_688091b7d774832e84d6a163d16cc039