### PR TITLE
Simplify flip clock display

### DIFF
--- a/assets/css/flipclock.css
+++ b/assets/css/flipclock.css
@@ -4,7 +4,6 @@
   justify-content: center;
   align-items: center;
   gap: 8px;
-  perspective: 300px;
 }
 
 .flip-digit {
@@ -17,46 +16,12 @@
   color: var(--emerald-border);
   font-family: var(--font-display);
   font-size: 2rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   overflow: hidden;
 }
 
-.flip-digit span {
-  position: absolute;
-  left: 0;
-  width: 100%;
-  height: 50%;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  backface-visibility: hidden;
-}
-
-.flip-digit .top {
-  top: 0;
-  border-bottom: 1px solid var(--emerald-border);
-  transform-origin: bottom;
-}
-
-.flip-digit .bottom {
-  bottom: 0;
-  border-top: 1px solid var(--emerald-border);
-  transform: rotateX(180deg);
-  transform-origin: top;
-}
-
-.flip-digit .top-flip {
-  top: 0;
-  border-bottom: 1px solid var(--emerald-border);
-  transform-origin: bottom;
-  animation: flipTop 0.5s forwards;
-}
-
-.flip-digit .bottom-flip {
-  bottom: 0;
-  border-top: 1px solid var(--emerald-border);
-  transform-origin: top;
-  animation: flipBottom 0.5s forwards;
-}
 
 .separator {
   font-family: var(--font-display);
@@ -65,15 +30,6 @@
   color: var(--emerald-border);
 }
 
-@keyframes flipTop {
-  0% { transform: rotateX(0); }
-  100% { transform: rotateX(-90deg); }
-}
-
-@keyframes flipBottom {
-  0% { transform: rotateX(90deg); }
-  100% { transform: rotateX(0); }
-}
 
 /* Size modifiers */
 .flip-clock.flip-small .flip-digit {

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -43,7 +43,7 @@ document.addEventListener('DOMContentLoaded', () => {
     function createDigit() {
       const d = document.createElement('div');
       d.className = 'flip-digit';
-      d.innerHTML = '<span class="top">0</span><span class="bottom">0</span>';
+      d.textContent = '0';
       return d;
     }
 
@@ -64,26 +64,8 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     function flipTo(digitEl, newNumber) {
-      const top = digitEl.querySelector('.top');
-      const bottom = digitEl.querySelector('.bottom');
-      if (top.textContent === newNumber) return;
-
-      const topFlip = document.createElement('span');
-      topFlip.className = 'top-flip';
-      topFlip.textContent = top.textContent;
-
-      const bottomFlip = document.createElement('span');
-      bottomFlip.className = 'bottom-flip';
-      bottomFlip.textContent = newNumber;
-
-      digitEl.appendChild(topFlip);
-      digitEl.appendChild(bottomFlip);
-
-      top.textContent = newNumber;
-      bottom.textContent = newNumber;
-
-      topFlip.addEventListener('animationend', () => topFlip.remove());
-      bottomFlip.addEventListener('animationend', () => bottomFlip.remove());
+      if (digitEl.textContent === newNumber) return;
+      digitEl.textContent = newNumber;
     }
 
     function updateClock() {


### PR DESCRIPTION
## Summary
- simplify creation and update of clock digits
- remove flip animation rules
- use flexbox centering for clock digits

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68809224c314832ea7372089073c518d