### PR TITLE
Add countdown labels

### DIFF
--- a/assets/css/flipclock.css
+++ b/assets/css/flipclock.css
@@ -2,7 +2,7 @@
 .flip-clock {
   display: flex;
   justify-content: center;
-  align-items: center;
+  align-items: flex-start;
   gap: 8px;
 }
 
@@ -30,6 +30,23 @@
   color: var(--emerald-border);
 }
 
+.flip-group {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.digit-row {
+  display: flex;
+}
+
+.flip-label {
+  margin-top: 4px;
+  color: var(--emerald-border);
+  font-family: var(--font-heading);
+  letter-spacing: 0.05em;
+}
+
 
 /* Size modifiers */
 .flip-clock.flip-small .flip-digit {
@@ -43,6 +60,10 @@
   line-height: 48px;
 }
 
+.flip-clock.flip-small .flip-label {
+  font-size: 0.7rem;
+}
+
 .flip-clock.flip-large .flip-digit {
   width: 60px;
   height: 90px;
@@ -52,4 +73,8 @@
 .flip-clock.flip-large .separator {
   font-size: 3.2rem;
   line-height: 90px;
+}
+
+.flip-clock.flip-large .flip-label {
+  font-size: 1rem;
 }

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -49,18 +49,40 @@ document.addEventListener('DOMContentLoaded', () => {
 
     function setupClock() {
       countdownEl.classList.add('flip-clock');
-      const total = 3 + 2 + 2 + 2; // days, hours, minutes, seconds
-      for (let i = 0; i < total; i++) {
-        const digit = createDigit();
-        digits.push(digit);
-        countdownEl.appendChild(digit);
-        if (i === 2 || i === 4 || i === 6) {
+      const groups = [
+        { size: 3, label: 'Days' },
+        { size: 2, label: 'Hours' },
+        { size: 2, label: 'Minutes' },
+        { size: 2, label: 'Seconds' },
+      ];
+
+      groups.forEach((grp, idx) => {
+        const groupEl = document.createElement('div');
+        groupEl.className = 'flip-group';
+
+        const row = document.createElement('div');
+        row.className = 'digit-row';
+        for (let i = 0; i < grp.size; i++) {
+          const digit = createDigit();
+          digits.push(digit);
+          row.appendChild(digit);
+        }
+        groupEl.appendChild(row);
+
+        const labelEl = document.createElement('div');
+        labelEl.className = 'flip-label';
+        labelEl.textContent = grp.label;
+        groupEl.appendChild(labelEl);
+
+        countdownEl.appendChild(groupEl);
+
+        if (idx < groups.length - 1) {
           const sep = document.createElement('span');
           sep.className = 'separator';
           sep.textContent = ':';
           countdownEl.appendChild(sep);
         }
-      }
+      });
     }
 
     function flipTo(digitEl, newNumber) {


### PR DESCRIPTION
## Summary
- tweak countdown clock script to include a label for Days/Hours/Minutes/Seconds
- style new countdown labels for small and large clocks

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68811db9e6f8832e8f7a00d1bef16bb4