### PR TITLE
Add save-the-date landing page

### DIFF
--- a/save-the-date/assets/css/save-the-date.css
+++ b/save-the-date/assets/css/save-the-date.css
@@ -1,0 +1,148 @@
+/* Styles for Save the Date page */
+@import url('https://fonts.googleapis.com/css2?family=Great+Vibes&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Raleway:wght@400;600&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Allura&display=swap');
+
+:root {
+  --bg-emerald-dark: #002d1f;
+  --emerald-overlay: rgba(0,0,0,0.22);
+  --emerald-border: #014421;
+  --emerald-hover: #015e3c;
+  --emerald-accent: #00975c;
+  --white: #fff;
+  --gray-light: #e4e4e4;
+  --font-body: 'Raleway', sans-serif;
+  --font-heading: 'Allura', cursive;
+  --card-radius: 20px;
+  --btn-radius: 28px;
+  --t-fast: 0.18s;
+  --t-med: 0.7s;
+  --ease-med: ease;
+}
+
+html, body {
+  margin: 0;
+  padding: 0;
+  width: 100%;
+  min-height: 100vh;
+  overflow-x: hidden;
+  background: var(--bg-emerald-dark);
+  font-family: var(--font-body);
+  color: var(--white);
+}
+
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
+.background-video {
+  position: fixed;
+  inset: 0;
+  background: url('../video-fallback.jpg') center/cover no-repeat;
+  overflow: hidden;
+  z-index: 0;
+}
+.background-video video {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: opacity var(--t-med) var(--ease-med);
+}
+
+.video-overlay {
+  position: fixed;
+  inset: 0;
+  background: var(--emerald-overlay);
+  z-index: 1;
+  pointer-events: none;
+}
+
+.intro-card-container {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 2;
+  opacity: 0;
+  transition: opacity var(--t-med) var(--ease-med);
+  pointer-events: none;
+}
+.intro-card-container.visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.flip-card {
+  background: transparent;
+  width: 320px;
+  height: 360px;
+  perspective: 1000px;
+}
+.flip-inner {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  text-align: center;
+  transition: transform 0.6s;
+  transform-style: preserve-3d;
+}
+.flip-card.flipped .flip-inner {
+  transform: rotateY(180deg);
+}
+.flip-front,
+.flip-back {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  backface-visibility: hidden;
+  background: var(--white);
+  color: #222;
+  border-radius: var(--card-radius);
+  box-shadow: 0 8px 40px rgba(0,0,0,0.12);
+  border: 1.5px solid var(--gray-light);
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+.flip-front:hover {
+  box-shadow: 0 12px 48px rgba(1,68,33,0.18);
+  border: 2px solid var(--emerald-border);
+  transform: translateY(-2px) scale(1.02);
+}
+.flip-back {
+  transform: rotateY(180deg);
+}
+
+.wedding-names {
+  font-family: var(--font-heading);
+  font-size: 2.7rem;
+  font-weight: 600;
+  margin: 0 0 1rem;
+  letter-spacing: .07em;
+  color: var(--emerald-border);
+  text-align: center;
+}
+.wedding-date {
+  font-size: 1.18rem;
+  color: var(--emerald-accent);
+  margin-bottom: 2.3rem;
+  letter-spacing: .04em;
+  text-align: center;
+}
+
+.flip-back p {
+  font-size: 1rem;
+  line-height: 1.4;
+  margin: 0;
+}
+
+@media (max-width: 600px) {
+  .flip-card {
+    width: 90%;
+  }
+}

--- a/save-the-date/assets/js/save-the-date.js
+++ b/save-the-date/assets/js/save-the-date.js
@@ -1,0 +1,27 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const introCard = document.getElementById('introCard');
+  if (introCard) {
+    setTimeout(() => introCard.classList.add('visible'), 3000);
+    introCard.addEventListener('click', () => {
+      introCard.querySelector('.flip-card')?.classList.toggle('flipped');
+    });
+  }
+
+  const countdownEl = document.getElementById('countdown');
+  if (countdownEl) {
+    const target = new Date('2026-09-12T00:00:00');
+    const interval = setInterval(() => {
+      const diff = target - Date.now();
+      if (diff <= 0) {
+        clearInterval(interval);
+        countdownEl.textContent = "It's today!";
+        return;
+      }
+      const days = Math.floor(diff / (1000*60*60*24));
+      const hours = Math.floor((diff/ (1000*60*60)) % 24);
+      const minutes = Math.floor((diff/ (1000*60)) % 60);
+      const seconds = Math.floor((diff/1000) % 60);
+      countdownEl.textContent = `${days}d ${hours}h ${minutes}m ${seconds}s`;
+    }, 1000);
+  }
+});

--- a/save-the-date/index.html
+++ b/save-the-date/index.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+  <title>Save the Date</title>
+  <link rel="icon" type="image/png" href="../assets/images/favicon.png">
+  <link rel="stylesheet" href="assets/css/save-the-date.css">
+</head>
+<body class="no-scroll">
+  <div class="background-video">
+    <video autoplay muted loop playsinline poster="../assets/video-fallback.jpg">
+      <source src="../assets/video.mp4" type="video/mp4">
+      <img src="../assets/video-fallback.jpg" alt="Video fallback" style="width:100%;height:100%;object-fit:cover">
+    </video>
+  </div>
+  <div class="video-overlay"></div>
+
+  <div class="intro-card-container" id="introCard">
+    <div class="flip-card">
+      <div class="flip-inner">
+        <div class="flip-front">
+          <h1 class="wedding-names">Christopher<br>&amp;<br>Lorraine</h1>
+          <div class="wedding-date">September 12, 2026&nbsp;&bull;&nbsp;Portola, CA</div>
+          <div id="countdown"></div>
+        </div>
+        <div class="flip-back">
+          <p>Wedding details and site coming soon, please plan in advance. We will release room blocks in a few months. Out of towners should plan on a weekend trip. If you definitely cannot make it please inform Chris or Lorraine.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <script src="assets/js/save-the-date.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create new folder `save-the-date` containing standalone landing page
- implement flip card that reveals details about the wedding
- add dedicated stylesheet and script for countdown and flip interaction

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688156cdc964832eb22c8de27aa902bd