### PR TITLE
Fix font imports

### DIFF
--- a/assets/css/theme.css
+++ b/assets/css/theme.css
@@ -1,4 +1,5 @@
-@import url('https://fonts.googleapis.com/css2?family=Great+Vibes&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Raleway:wght@400;600&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Allura&display=swap');
 
 :root {
   /* colors */

--- a/save-the-date/assets/css/save-the-date.css
+++ b/save-the-date/assets/css/save-the-date.css
@@ -1,5 +1,4 @@
 /* Styles for Save the Date page */
-@import url('https://fonts.googleapis.com/css2?family=Great+Vibes&display=swap');
 @import url('https://fonts.googleapis.com/css2?family=Raleway:wght@400;600&display=swap');
 @import url('https://fonts.googleapis.com/css2?family=Allura&display=swap');
 


### PR DESCRIPTION
## Summary
- import Raleway and Allura fonts in `theme.css`
- remove unused Great Vibes import from `theme.css`
- remove Great Vibes import from Save the Date styles

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6881d3f005f8832eaf38194bcfcf507a