### PR TITLE
Adjust sticky nav and flipbook header fonts

### DIFF
--- a/assets/css/story.css
+++ b/assets/css/story.css
@@ -139,7 +139,7 @@
 /* heading inside each text-page spread */
 .text-page-heading {
   font-family: var(--font-heading);
-  font-size:   1.5rem;
+  font-size:   1.7rem; /* Slightly larger for better readability */
   color:       var(--emerald-border);
   text-align:  center;
   margin:      0 1rem 1rem;  /* small gutter below */

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -25,7 +25,7 @@
 .main-nav a {
   color:           var(--white);
   font-family:     var(--font-nav);
-  font-size:       1rem;
+  font-size:       1.1rem; /* Slightly larger for improved legibility */
   font-weight:     500;
   padding:         0.25rem 0.5rem;
   border-radius:   16px;
@@ -179,7 +179,7 @@ body {
     margin: 0;
   }
   .site-header .main-nav a {
-    font-size: 1rem;
+    font-size: 1.1rem; /* match default nav size */
     padding: 0.25rem 0.5rem;
   }
 }


### PR DESCRIPTION
## Summary
- enlarge nav link font for sticky header
- enlarge header text in flipbook pages

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6882a1c2c05c832ebf1208c18cb42170