### PR TITLE
Switch to Cinzel Decorative and Spectral fonts

### DIFF
--- a/assets/css/theme.css
+++ b/assets/css/theme.css
@@ -1,5 +1,5 @@
-@import url('https://fonts.googleapis.com/css2?family=Raleway:wght@400;600&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=Allura&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Cinzel+Decorative:wght@400;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Spectral:wght@400;700&display=swap');
 
 :root {
   /* colors */
@@ -11,9 +11,9 @@
   --white: #fff;
   --gray-light: #e4e4e4;
   /* fonts */
-  --font-body: 'Raleway', sans-serif;
-  --font-heading: 'Allura', cursive;
-  --font-nav: 'Allura', cursive;
+  --font-body: 'Spectral', serif;
+  --font-heading: 'Cinzel Decorative', cursive;
+  --font-nav: 'Cinzel Decorative', cursive;
   /* sizing */
   --card-radius: 20px;
   --photo-size: 96px;


### PR DESCRIPTION
## Summary
- use Cinzel Decorative for headings and nav
- use Spectral for paragraph text

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_6882ebbca5e4832ea5a5387ec11ec48e