### PR TITLE
Improve mobile layout

### DIFF
--- a/assets/css/flipclock.css
+++ b/assets/css/flipclock.css
@@ -78,3 +78,12 @@
 .flip-clock.flip-large .flip-label {
   font-size: 1rem;
 }
+
+/* Keep clocks contained on small screens */
+@media (max-width: 600px) {
+  .flip-clock {
+    transform: scale(0.8);
+    transform-origin: center;
+    margin: 0 auto;
+  }
+}

--- a/assets/css/home.css
+++ b/assets/css/home.css
@@ -19,6 +19,7 @@
 @media (max-width: 600px) {
   .hero-img { width:120px; height:120px; }
   .big-rsvp-btn { font-size:1rem; padding:.7rem 2rem; }
+  #countdown { margin: 0 auto; }
 }
 
 /* Centered button rows on home page */

--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -119,6 +119,9 @@
     padding: 1.4rem .5rem;
     max-width: 98%;
   }
+  #countdown {
+    margin: 0 auto;
+  }
   .circle-photo {
     width: 68px;
     height: 68px;

--- a/assets/css/story.css
+++ b/assets/css/story.css
@@ -102,19 +102,19 @@
 /* responsive shrink on small screens */
 @media (max-width: 700px) {
   #flipbook {
-    width:  98vw;
+    width: 95vw;
     max-width: 100vw;
-    /* keep pages side-by-side on small screens */
-    flex-direction: row;
-    height: calc(98vw * 0.66);
+    flex-direction: column;       /* show one page at a time */
+    height: auto;
   }
-  #flipbook .page{
-     border-radius: var(--card-radius);
-     margin-bottom: 0;
+  #flipbook .page {
+    flex: 0 0 100%;
+    border-radius: var(--card-radius);
+    margin-bottom: 0;
   }
   .text-page { padding: 1rem; }
-  .image-page{ padding: 0.5rem; }
-  .text-page .text-content { font-size: 1rem; }
+  .image-page { padding: 0.5rem; }
+  .text-page .text-content { font-size: 0.9rem; }
 }
 
 /* Center the story-page wrapper and give room for nav */

--- a/assets/js/story.js
+++ b/assets/js/story.js
@@ -10,26 +10,40 @@ document.addEventListener('DOMContentLoaded', () => {
   // 3) Remove the preload class so pages can become visible
   flipbook.classList.remove('preload');
 
-  // 4) Show two‑page spreads (0→ pages[0]&pages[1], 1→ pages[2]&pages[3], etc.)
-  let spread = 0;
+  // 4) Determine if we should show single pages on small screens
+  const singlePage = window.matchMedia('(max-width: 700px)').matches;
+  let index = 0; // page index or spread index
   const prev = document.getElementById('prevBtn');
   const next = document.getElementById('nextBtn');
 
-  function showSpread(n) {
+  function show(n) {
     pages.forEach((p, i) => {
-      p.style.display = (i === n*2 || i === n*2 + 1) ? 'flex' : 'none';
+      if (singlePage) {
+        p.style.display = i === n ? 'flex' : 'none';
+      } else {
+        p.style.display = (i === n*2 || i === n*2 + 1) ? 'flex' : 'none';
+      }
     });
     if (prev) prev.style.display = n === 0 ? 'none' : '';
-    if (next) next.style.display = (n + 1) * 2 >= pages.length ? 'none' : '';
+    if (next) {
+      const atEnd = singlePage ? n >= pages.length - 1 : (n + 1) * 2 >= pages.length;
+      next.style.display = atEnd ? 'none' : '';
+    }
   }
+
   if (prev) prev.addEventListener('click', e => {
     e.preventDefault();
-    if (spread > 0) showSpread(--spread);
-  });
-  if (next) next.addEventListener('click', e => {
-    e.preventDefault();
-    if ((spread + 1)*2 < pages.length) showSpread(++spread);
+    if (index > 0) show(--index);
   });
 
-  showSpread(spread);
+  if (next) next.addEventListener('click', e => {
+    e.preventDefault();
+    if (singlePage) {
+      if (index < pages.length - 1) show(++index);
+    } else if ((index + 1) * 2 < pages.length) {
+      show(++index);
+    }
+  });
+
+  show(index);
 });


### PR DESCRIPTION
## Summary
- center mobile countdown clocks and scale them down
- use single-page flipbook layout on small screens
- reduce mobile text size in story flipbook

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688311c2f4c8832ea1d50b67535c2b23