### PR TITLE
Remove countdown mobile resizing

### DIFF
--- a/assets/css/flipclock.css
+++ b/assets/css/flipclock.css
@@ -79,35 +79,3 @@
   font-size: 1rem;
 }
 
-/* Keep clocks contained on small screens */
-@media (max-width: 600px) {
-  .flip-clock {
-    margin: 0 auto;
-  }
-  /* Reduce the large clock size for mobile */
-  .flip-clock.flip-large .flip-digit {
-    width: 45px;
-    height: 70px;
-    font-size: 2.2rem;
-  }
-  .flip-clock.flip-large .separator {
-    font-size: 2.4rem;
-    line-height: 70px;
-  }
-  .flip-clock.flip-large .flip-label {
-    font-size: 0.9rem;
-  }
-  /* Reduce the small clock size for mobile */
-  .flip-clock.flip-small .flip-digit {
-    width: 26px;
-    height: 40px;
-    font-size: 1.3rem;
-  }
-  .flip-clock.flip-small .separator {
-    font-size: 1.5rem;
-    line-height: 40px;
-  }
-  .flip-clock.flip-small .flip-label {
-    font-size: 0.75rem;
-  }
-}

--- a/assets/css/home.css
+++ b/assets/css/home.css
@@ -19,7 +19,6 @@
 @media (max-width: 600px) {
   .hero-img { width:120px; height:120px; }
   .big-rsvp-btn { font-size:1rem; padding:.7rem 2rem; }
-  #countdown { margin: 0 auto; }
 }
 
 /* Centered button rows on home page */

--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -119,9 +119,6 @@
     padding: 1.4rem .5rem;
     max-width: 98%;
   }
-  #countdown {
-    margin: 0 auto;
-  }
   .circle-photo {
     width: 68px;
     height: 68px;


### PR DESCRIPTION
## Summary
- remove mobile-only flip clock styles
- keep home and index page countdown consistent across devices

## Testing
- `grep -n countdown -R assets/css`

------
https://chatgpt.com/codex/tasks/task_e_688320a04754832e8afe544bcfe63f35