### PR TITLE
Change button color to match background

### DIFF
--- a/assets/css/home.css
+++ b/assets/css/home.css
@@ -37,7 +37,7 @@
   display: inline-block;
   padding: 1rem 3rem;
   font-size: 1.4rem;
-  background: var(--emerald-accent);
+  background: var(--bg-emerald-dark);
   color: var(--white);
   border: 2px solid var(--emerald-border);
 }

--- a/assets/css/theme.css
+++ b/assets/css/theme.css
@@ -65,11 +65,29 @@ html, body {
   pointer-events: none;
 }
 
-/* card & button base */
-.card, .main-btn {
+/* base card styling */
+.card {
   background: var(--white);
   color: #222;
   border-radius: var(--card-radius);
+  box-shadow: 0 8px 40px rgba(0,0,0,0.12);
+  border: 2px solid var(--emerald-border);
+  font-family: var(--font-heading);
+  text-decoration: none;
+  cursor: pointer;
+  transition:
+    background var(--t-fast) var(--ease-med),
+    color var(--t-fast) var(--ease-med),
+    transform var(--t-fast) var(--ease-med),
+    opacity var(--t-med) var(--ease-med);
+}
+
+/* buttons share the same structure as cards but use the
+   site background color for their fill */
+.main-btn {
+  background: var(--bg-emerald-dark);
+  color: var(--white);
+  border-radius: var(--btn-radius);
   box-shadow: 0 8px 40px rgba(0,0,0,0.12);
   border: 2px solid var(--emerald-border);
   font-family: var(--font-heading);


### PR DESCRIPTION
## Summary
- separate card and button styles in `theme.css`
- style buttons with background var(--bg-emerald-dark)
- update Home page button color to use new green

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68868cfcc5a4832ea1ba4d5c013d2d3c