### PR TITLE
Simplify travel page styling

### DIFF
--- a/assets/css/accommodations.css
+++ b/assets/css/accommodations.css
@@ -1,53 +1,12 @@
 /* accommodations.css — page‑specific */
 
-/* Section headings */
-.booking-instructions h2,
-.hotel-details h2,
-.airport-info h2,
-.directions h2,
-.map-section h2 {
-  font-family: var(--font-heading);
-  font-size:   1.8rem;
-  color:       var(--emerald-border);
-  text-align:  center;
-  margin:      2rem 0 1rem;
-}
-
-
-/* Booking steps */
-.booking-instructions ol,
-.directions ol {
-  margin: 0 0 1rem 1.4rem;
-}
-.booking-instructions li,
-.directions li {
-  margin-bottom: 0.6rem;
-}
-
-/* Inline note style */
-.booking-instructions .note {
-  font-style: italic;
-  font-size: 1rem;
-  margin-top: 0.5rem;
-}
+/* Section styles now shared via .info-section in style.css */
 
 
 /* Responsive map/embed */
 .iframe-container {
-  position: relative;
-  width: 100%;
   padding-bottom: 56.25%;  /* 16:9 ratio */
-  overflow: hidden;
-  border-radius: var(--card-radius);
-  box-shadow:    0 4px 24px rgba(0,0,0,0.1);
   margin-top: 1rem;
-}
-.iframe-container iframe {
-  position: absolute;
-  top:    0; left: 0;
-  width:  100%;
-  height: 100%;
-  border: 0;
 }
 
 /* Mobile tweaks */
@@ -55,8 +14,7 @@
   .content-container h1 {
     font-size: 2rem;
   }
-  .booking-instructions h2,
-  .directions h2 {
+  .info-section h2 {
     font-size: 1.4rem;
   }
 }

--- a/assets/css/events.css
+++ b/assets/css/events.css
@@ -76,19 +76,7 @@
 
 /* Responsive iframe container for map */
 .iframe-container {
-  position: relative;
-  width: 100%;
   padding-bottom: 56.25%; /* 16:9 aspect ratio */
-  overflow: hidden;
-  border-radius: var(--card-radius);
-  box-shadow: 0 4px 24px rgba(0,0,0,0.1);
-}
-.iframe-container iframe {
-  position: absolute;
-  top:    0; left: 0;
-  width:  100%;
-  height: 100%;
-  border: 0;
 }
 
 /* Mobile tweaks */

--- a/assets/css/rsvp.css
+++ b/assets/css/rsvp.css
@@ -15,19 +15,7 @@
 
 /* Responsive iframe wrapper */
 .iframe-container {
-  position: relative;
-  width: 100%;
   padding-bottom: 75%; /* 4:3 aspect ratio */
-  overflow: hidden;
-  border-radius: var(--card-radius);
-  box-shadow: 0 4px 24px rgba(0,0,0,0.1);
-}
-.iframe-container iframe {
-  position: absolute;
-  top:    0; left: 0;
-  width:  100%;
-  height: 100%;
-  border: 0;
 }
 
 /* Mobile tweak */

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -152,6 +152,42 @@ body {
   color: var(--emerald-border);
 }
 
+/* Standard section formatting used across pages */
+.info-section h2 {
+  font-family: var(--font-heading);
+  font-size:   1.8rem;
+  color:       var(--emerald-border);
+  text-align:  center;
+  margin:      2rem 0 1rem;
+}
+.info-section ol {
+  margin: 0 0 1rem 1.4rem;
+}
+.info-section li {
+  margin-bottom: 0.6rem;
+}
+.info-section .note {
+  font-style: italic;
+  font-size: 1rem;
+  margin-top: 0.5rem;
+}
+
+/* Generic responsive iframe wrapper */
+.iframe-container {
+  position: relative;
+  width: 100%;
+  overflow: hidden;
+  border-radius: var(--card-radius);
+  box-shadow: 0 4px 24px rgba(0,0,0,0.1);
+}
+.iframe-container iframe {
+  position: absolute;
+  top: 0; left: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
+}
+
 @media (max-width: 600px) {
   .coming-soon-banner {
     font-size: 1.2rem;

--- a/travel.html
+++ b/travel.html
@@ -33,7 +33,7 @@
   <!-- ── Travel & Accommodation Content ── -->
   <main class="content-container">
     <h1>Travel</h1>
-<section class="airport-info">
+<section class="airport-info info-section">
       <h2>Airport & Car Rentals</h2>
       <p>
         Reno‑Tahoe International Airport is a 50‑minute drive away. We recommend renting a car—
@@ -44,7 +44,7 @@
       </p>
     </section>
 
-    <section class="directions">
+    <section class="directions info-section">
       <h2>Directions from Reno‑Tahoe Airport</h2>
       <ol>
         <li>Take the left ramp onto I‑580 N.</li>
@@ -66,7 +66,7 @@
       essence of mountain luxury, inviting guests to immerse themselves in the natural world,
       and serves as the perfect launchpad for adventures—from forest trails to onsite activities.
     </p>
-<section class="hotel-details">
+<section class="hotel-details info-section">
       <h2>Hotel Details</h2>
       <p>
         We’ve reserved all 52 uniquely styled rooms exclusively for our group until 60 days before
@@ -78,7 +78,7 @@
         Chalet View Lodge cannot accommodate early check‑ins or late check‑outs.
       </p>
     </section>
-    <section class="booking-instructions">
+    <section class="booking-instructions info-section">
       <h2>How to Book Your Room</h2>
       <ol>
         <li>
@@ -98,7 +98,7 @@
         For help, email <a href="mailto:help@chaletview.com">help@chaletview.com</a>.
       </p>
     </section>
-    <section class="map-section">
+    <section class="map-section info-section">
       <h2>Venue Map</h2>
       <div class="iframe-container">
         <iframe


### PR DESCRIPTION
## Summary
- create unified `.info-section` styling for headings and lists
- consolidate common iframe CSS
- update travel page to use the new section class
- clean up page‑specific CSS

## Testing
- `ls`

------
https://chatgpt.com/codex/tasks/task_e_688700940460832e875f6020507ae1e3