### PR TITLE
Improve mobile nav scroll cues

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -239,19 +239,36 @@ body {
   .site-header .main-nav {
     position: relative;
   }
+  .site-header .main-nav::before,
   .site-header .main-nav::after {
-    content: '›';
     position: absolute;
-    right: 0;
     top: 0;
     bottom: 0;
     display: flex;
     align-items: center;
-    padding-right: 0.5rem;
-    color: var(--white);
-    font-size: 1.3rem;
     pointer-events: none;
+    font-size: 1.8rem; /* larger arrow indicator */
+    color: var(--white);
+    opacity: 0;
+    transition: opacity var(--t-fast) var(--ease-med);
+  }
+  .site-header .main-nav::before {
+    content: '‹';
+    left: 0;
+    padding-left: 0.75rem;
+    background: linear-gradient(to left, rgba(0,0,0,0), rgba(0,0,0,0.85));
+  }
+  .site-header .main-nav::after {
+    content: '›';
+    right: 0;
+    padding-right: 0.75rem;
     background: linear-gradient(to right, rgba(0,0,0,0), rgba(0,0,0,0.85));
+  }
+  .site-header .main-nav.show-left::before {
+    opacity: 1;
+  }
+  .site-header .main-nav.show-right::after {
+    opacity: 1;
   }
 }
 

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -117,4 +117,27 @@ document.addEventListener('DOMContentLoaded', () => {
     updateClock();
     timer = setInterval(updateClock, 1000);
   }
+
+  // ── 4) Mobile nav scroll indicators ──
+  const mainNav = document.querySelector('.site-header .main-nav');
+  const navList = mainNav?.querySelector('ul');
+  if (mainNav && navList) {
+    const updateNavScroll = () => {
+      const maxScroll = navList.scrollWidth - navList.clientWidth;
+      const cur = navList.scrollLeft;
+      if (cur > 0) {
+        mainNav.classList.add('show-left');
+      } else {
+        mainNav.classList.remove('show-left');
+      }
+      if (cur < maxScroll) {
+        mainNav.classList.add('show-right');
+      } else {
+        mainNav.classList.remove('show-right');
+      }
+    };
+    navList.addEventListener('scroll', updateNavScroll);
+    window.addEventListener('resize', updateNavScroll);
+    updateNavScroll();
+  }
 });


### PR DESCRIPTION
## Summary
- enlarge mobile navigation scroll arrows
- show left/right scroll cues when appropriate

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6887262f9aa8832eb5b4262f76c0a38b