### PR TITLE
Remove active nav highlight on mobile

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -235,12 +235,6 @@ body {
     font-size: 1.1rem; /* match default nav size */
     padding: 0.25rem 0.5rem;
   }
-  /* Highlight the active page in the sticky nav */
-  .site-header .main-nav a.active {
-    background: var(--white);
-    color: var(--emerald-border);
-    border-radius: 16px;
-  }
   /* Visual cue that nav can scroll */
   .site-header .main-nav {
     position: relative;


### PR DESCRIPTION
## Summary
- update mobile styles to stop highlighting the active navigation link

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6887b62b4590832e88abd94853d36cd6