### PR TITLE
Add color palette to attire page

### DIFF
--- a/assets/css/attire.css
+++ b/assets/css/attire.css
@@ -24,6 +24,31 @@
   line-height: 1.6;
 }
 
+.color-palette {
+  text-align: center;
+  margin: 2rem 0;
+}
+
+.palette {
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.color-circle {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  border: 2px solid var(--white);
+}
+
+.color-circle.black { background: #000; }
+.color-circle.gold { background: #d4af37; }
+.color-circle.brown { background: #8b4513; }
+.color-circle.tan { background: #d2b48c; }
+.color-circle.creme { background: #fffdd0; }
+
 @media (max-width: 600px) {
   .attire-list {
     flex-direction: column;

--- a/attire.html
+++ b/attire.html
@@ -39,6 +39,17 @@
       <p>Our celebration calls for an upscale evening look with sleek fabrics and a touch of sparkle.</p>
     </section>
 
+    <section class="color-palette">
+      <h2>Color Palette</h2>
+      <div class="palette">
+        <span class="color-circle black"></span>
+        <span class="color-circle gold"></span>
+        <span class="color-circle brown"></span>
+        <span class="color-circle tan"></span>
+        <span class="color-circle creme"></span>
+      </div>
+    </section>
+
     <section class="dos-donts">
       <h2>What to Wear</h2>
       <div class="attire-list">


### PR DESCRIPTION
## Summary
- add color palette section to guest attire page
- style color circles for black, gold, brown, tan and creme options

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688edf014610832e88c652e9b1b6188d