### PR TITLE
Center 'Please Avoid' list on Attire page

### DIFF
--- a/assets/css/attire.css
+++ b/assets/css/attire.css
@@ -30,11 +30,22 @@
   margin-bottom: 0.5rem;
 }
 
-.attire-section ul,
+.attire-section ul {
+  margin: 0;
+  padding-left: 1.2rem;
+  line-height: 1.6;
+}
+
+.donts {
+  text-align: center;
+}
+
 .donts ul {
   margin: 0;
   padding-left: 1.2rem;
   line-height: 1.6;
+  display: inline-block;
+  text-align: left;
 }
 
 .color-palette {


### PR DESCRIPTION
## Summary
- Center the "Please Avoid" list on the Attire page by adding a dedicated `.donts` rule and centering the list block.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688ef7349a48832e90abd636f7b6b812