### PR TITLE
Update page titles for Becoming Cummings theme

### DIFF
--- a/attire.html
+++ b/attire.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Guest Attire</title>
+    <title>Becoming Cummings | Guest Attire</title>
     <link rel="icon" href="assets/images/favicon.png" type="image/png" />
 
     <!-- site-wide -->

--- a/events.html
+++ b/events.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Our Events</title>
+    <title>Becoming Cummings | Our Events</title>
     <link rel="icon" href="assets/images/favicon.png" type="image/png" />
 
     <!-- site‑wide -->

--- a/faqs.html
+++ b/faqs.html
@@ -7,7 +7,7 @@
       name="viewport"
       content="width=device-width, initial-scale=1, maximum-scale=1"
     />
-    <title>Frequently Asked Questions</title>
+    <title>Becoming Cummings | Frequently Asked Questions</title>
     <link rel="icon" href="assets/images/favicon.png" type="image/png" />
 
     <!-- 1) theme tokens -->

--- a/gallery.html
+++ b/gallery.html
@@ -7,7 +7,7 @@
       name="viewport"
       content="width=device-width, initial-scale=1, maximum-scale=1"
     />
-    <title>Gallery</title>
+    <title>Becoming Cummings | Gallery</title>
     <link rel="icon" type="image/png" href="assets/images/favicon.png" />
 
     <link rel="stylesheet" href="assets/css/theme.css" />

--- a/home.html
+++ b/home.html
@@ -7,7 +7,7 @@
       name="viewport"
       content="width=device-width, initial-scale=1, maximum-scale=1"
     />
-    <title>When Cummings Meets Galano</title>
+    <title>Becoming Cummings</title>
     <link rel="icon" type="image/png" href="assets/images/favicon.png" />
 
     <link rel="stylesheet" href="assets/css/theme.css" />

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
       name="viewport"
       content="width=device-width, initial-scale=1, maximum-scale=1"
     />
-    <title>When Cummings Meets Galano</title>
+    <title>Becoming Cummings</title>
     <link rel="icon" type="image/png" href="assets/images/favicon.png" />
 
     <link rel="stylesheet" href="assets/css/theme.css" />

--- a/rsvp.html
+++ b/rsvp.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>RSVP</title>
+    <title>Becoming Cummings | RSVP</title>
     <link rel="icon" href="assets/images/favicon.png" type="image/png" />
 
     <!-- site-wide -->

--- a/travel.html
+++ b/travel.html
@@ -7,7 +7,7 @@
       name="viewport"
       content="width=device-width, initial-scale=1, maximum-scale=1"
     />
-    <title>Travel &amp; Accommodations</title>
+    <title>Becoming Cummings | Travel &amp; Accommodations</title>
     <link rel="icon" href="assets/images/favicon.png" type="image/png" />
     <link rel="stylesheet" href="assets/css/theme.css" />
     <link rel="stylesheet" href="assets/css/style.css" />

--- a/wedding-party.html
+++ b/wedding-party.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Wedding Party</title>
+    <title>Becoming Cummings | Wedding Party</title>
     <link rel="icon" href="assets/images/favicon.png" type="image/png" />
 
     <!-- site‑wide -->


### PR DESCRIPTION
## Summary
- Replace site titles on landing and home pages with "Becoming Cummings"
- Prepend "Becoming Cummings" to RSVP, Events, Wedding Party, Attire, Gallery, Travel, and FAQ page titles

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f0ea0e5a8832eaee81f0bfe9d2cc9