### PR TITLE
Hide current page link in sticky header

### DIFF
--- a/attire.html
+++ b/attire.html
@@ -20,7 +20,6 @@
         <ul>
           <li><a href="our-story.html">Our Story</a></li>
           <li><a href="events.html">Events</a></li>
-          <li><a href="attire.html" class="active">Attire</a></li>
           <li><a href="wedding-party.html">Wedding Party</a></li>
           <li><a href="registry.html">Registry</a></li>
           <li><a href="travel.html">Travel</a></li>

--- a/events.html
+++ b/events.html
@@ -19,7 +19,6 @@
       <nav class="main-nav">
         <ul>
           <li><a href="our-story.html">Our Story</a></li>
-          <li><a href="events.html" class="active">Events</a></li>
           <li><a href="attire.html">Attire</a></li>
           <li><a href="wedding-party.html">Wedding Party</a></li>
           <li><a href="registry.html">Registry</a></li>

--- a/faqs.html
+++ b/faqs.html
@@ -30,7 +30,6 @@
           <li><a href="registry.html">Registry</a></li>
           <li><a href="travel.html">Travel</a></li>
           <li><a href="gallery.html">Gallery</a></li>
-          <li><a href="faqs.html" class="active">FAQs</a></li>
         </ul>
       </nav>
     </header>

--- a/gallery.html
+++ b/gallery.html
@@ -26,7 +26,6 @@
           <li><a href="wedding-party.html">Wedding Party</a></li>
           <li><a href="registry.html">Registry</a></li>
           <li><a href="travel.html">Travel</a></li>
-          <li><a href="gallery.html" class="active">Gallery</a></li>
           <li><a href="faqs.html">FAQs</a></li>
         </ul>
       </nav>

--- a/our-story.html
+++ b/our-story.html
@@ -22,7 +22,6 @@
       <a class="site-title" href="home.html">Becoming Cummings</a>
       <nav class="main-nav">
         <ul>
-          <li><a href="our-story.html" class="active">Our Story</a></li>
           <li><a href="events.html">Events</a></li>
           <li><a href="attire.html">Attire</a></li>
           <li><a href="wedding-party.html">Wedding Party</a></li>

--- a/travel.html
+++ b/travel.html
@@ -24,7 +24,6 @@
           <li><a href="attire.html">Attire</a></li>
           <li><a href="wedding-party.html">Wedding Party</a></li>
           <li><a href="registry.html">Registry</a></li>
-          <li><a href="travel.html" class="active">Travel</a></li>
           <li><a href="gallery.html">Gallery</a></li>
           <li><a href="faqs.html">FAQs</a></li>
         </ul>

--- a/wedding-party.html
+++ b/wedding-party.html
@@ -21,7 +21,6 @@
           <li><a href="our-story.html">Our Story</a></li>
           <li><a href="events.html">Events</a></li>
           <li><a href="attire.html">Attire</a></li>
-          <li><a href="wedding-party.html" class="active">Wedding Party</a></li>
           <li><a href="registry.html">Registry</a></li>
           <li><a href="travel.html">Travel</a></li>
           <li><a href="gallery.html">Gallery</a></li>


### PR DESCRIPTION
## Summary
- Remove navigation link to the current page across site headers.

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f93830ae8832ea8a1c710fb775fc6