### PR TITLE
Include dates in event schedule

### DIFF
--- a/events.html
+++ b/events.html
@@ -40,11 +40,13 @@
             <img src="assets/icons/reception.svg" alt="Welcome Party Icon" />
           </div>
           <div class="details">
-            <div class="time">6:00&nbsp;PM – 10:00&nbsp;PM</div>
+            <div class="time">
+              Friday, September 11, 2026&nbsp;·&nbsp;6:00&nbsp;PM –
+              10:00&nbsp;PM
+            </div>
             <h2 class="title">Welcome Party</h2>
             <p class="description">
-              Friday, September 11. Kick off the celebration with drinks and
-              light bites.
+              Kick off the celebration with drinks and light bites.
             </p>
           </div>
         </article>
@@ -55,11 +57,13 @@
             <img src="assets/icons/dinner.svg" alt="Brunch Icon" />
           </div>
           <div class="details">
-            <div class="time">11:00&nbsp;AM – 2:00&nbsp;PM</div>
+            <div class="time">
+              Saturday, September 12, 2026&nbsp;·&nbsp;11:00&nbsp;AM –
+              2:00&nbsp;PM
+            </div>
             <h2 class="title">Mimosa Brunch</h2>
             <p class="description">
-              Saturday morning. Ease into the day with mimosas and a casual
-              brunch.
+              Ease into the day with mimosas and a casual brunch.
             </p>
           </div>
         </article>
@@ -70,26 +74,13 @@
             <img src="assets/icons/ceremony.svg" alt="Ceremony Icon" />
           </div>
           <div class="details">
-            <div class="time">5:00&nbsp;PM</div>
+            <div class="time">
+              Saturday, September 12, 2026&nbsp;·&nbsp;5:00&nbsp;PM
+            </div>
             <h2 class="title">Wedding Ceremony</h2>
             <p class="description">
               Join us beneath the willow tree in the Rose Garden for the
               ceremony.
-            </p>
-          </div>
-        </article>
-
-        <!-- Cocktail Hour -->
-        <article class="event-card">
-          <div class="icon">
-            <img src="assets/icons/reception.svg" alt="Cocktail Icon" />
-          </div>
-          <div class="details">
-            <div class="time">6:00&nbsp;PM</div>
-            <h2 class="title">Cocktail Hour</h2>
-            <p class="description">
-              Hors d’œuvres & champagne on the Terrace Deck overlooking the
-              vineyards.
             </p>
           </div>
         </article>
@@ -100,11 +91,11 @@
             <img src="assets/icons/dinner.svg" alt="Reception Icon" />
           </div>
           <div class="details">
-            <div class="time">7:00&nbsp;PM</div>
+            <div class="time">
+              Saturday, September 12, 2026&nbsp;·&nbsp;7:00&nbsp;PM
+            </div>
             <h2 class="title">Reception</h2>
-            <p class="description">
-              Dinner and dancing in the Barn Hall.
-            </p>
+            <p class="description">Dinner and dancing in the Barn Hall.</p>
           </div>
         </article>
 
@@ -114,10 +105,44 @@
             <img src="assets/icons/reception.svg" alt="After Party Icon" />
           </div>
           <div class="details">
-            <div class="time">12:00&nbsp;AM</div>
+            <div class="time">
+              Saturday, September 12, 2026&nbsp;·&nbsp;12:00&nbsp;AM
+            </div>
             <h2 class="title">After Party</h2>
             <p class="description">
               Keep the celebration going with late-night snacks and music.
+            </p>
+          </div>
+        </article>
+
+        <!-- Farewell Cookout -->
+        <article class="event-card">
+          <div class="icon">
+            <img src="assets/icons/dinner.svg" alt="Cookout Icon" />
+          </div>
+          <div class="details">
+            <div class="time">
+              Sunday, September 13, 2026&nbsp;·&nbsp;Time&nbsp;TBD
+            </div>
+            <h2 class="title">Farewell Cookout</h2>
+            <p class="description">
+              Wrap up the weekend with a casual cookout.
+            </p>
+          </div>
+        </article>
+
+        <!-- For Those Still Around -->
+        <article class="event-card">
+          <div class="icon">
+            <img src="assets/icons/reception.svg" alt="Monday Icon" />
+          </div>
+          <div class="details">
+            <div class="time">
+              Monday, September 14, 2026&nbsp;·&nbsp;Time&nbsp;TBD
+            </div>
+            <h2 class="title">For Those Still Around</h2>
+            <p class="description">
+              We'll figure out a fun activity for anyone still in town.
             </p>
           </div>
         </article>


### PR DESCRIPTION
## Summary
- show event dates alongside times
- remove cocktail hour and add Sunday farewell cookout plus Monday TBD gathering

## Testing
- `npx --yes prettier --check events.html`
- `npx --yes htmlhint events.html` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689030ff987c832ea311140c60c4c6f8