### PR TITLE
Add simple SVG icons for events page

### DIFF
--- a/assets/images/icons/after-party.svg
+++ b/assets/images/icons/after-party.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" stroke="#014421" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="20" cy="44" r="6"/>
+  <path d="M26 44V20h12"/>
+  <circle cx="38" cy="28" r="6"/>
+  <path d="M44 28V8"/>
+</svg>

--- a/assets/images/icons/bonus-day.svg
+++ b/assets/images/icons/bonus-day.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" stroke="#014421" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M24 24a8 8 0 0 1 16 0c0 8-8 6-8 12v4"/>
+  <circle cx="32" cy="52" r="2"/>
+</svg>

--- a/assets/images/icons/ceremony.svg
+++ b/assets/images/icons/ceremony.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" stroke="#014421" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="32" cy="20" r="14"/>
+  <path d="M32 34v20"/>
+  <path d="M26 54h12"/>
+</svg>

--- a/assets/images/icons/farewell-cookout.svg
+++ b/assets/images/icons/farewell-cookout.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" stroke="#014421" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="32" cy="28" r="16"/>
+  <path d="M20 44l-4 12"/>
+  <path d="M44 44l4 12"/>
+  <path d="M32 44v12"/>
+</svg>

--- a/assets/images/icons/mimosa-brunch.svg
+++ b/assets/images/icons/mimosa-brunch.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" stroke="#014421" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M24 6h16l-5 28h-6z"/>
+  <path d="M32 34v14"/>
+  <path d="M24 52h16"/>
+</svg>

--- a/assets/images/icons/reception.svg
+++ b/assets/images/icons/reception.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" stroke="#014421" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="32" cy="32" r="14"/>
+  <circle cx="32" cy="32" r="6"/>
+  <path d="M14 14v36M18 14v36M14 14h4M14 22h4M14 30h4"/>
+  <path d="M50 14v36"/>
+</svg>

--- a/assets/images/icons/welcome-party.svg
+++ b/assets/images/icons/welcome-party.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" stroke="#014421" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="22" cy="22" r="12"/>
+  <circle cx="42" cy="18" r="10"/>
+  <path d="M22 34v20"/>
+  <path d="M42 28v20"/>
+</svg>

--- a/events.html
+++ b/events.html
@@ -37,7 +37,7 @@
         <!-- Welcome Party -->
         <article class="event-card">
           <div class="icon">
-            <img src="assets/images/IMG_2169.jpeg" alt="Welcome Party photo" />
+            <img src="assets/images/icons/welcome-party.svg" alt="Welcome party icon" />
           </div>
           <div class="details">
             <div class="time">
@@ -54,7 +54,7 @@
         <!-- Mimosa Brunch -->
         <article class="event-card">
           <div class="icon">
-            <img src="assets/images/IMG_2170.jpeg" alt="Mimosa Brunch photo" />
+            <img src="assets/images/icons/mimosa-brunch.svg" alt="Mimosa brunch icon" />
           </div>
           <div class="details">
             <div class="time">
@@ -71,7 +71,7 @@
         <!-- Ceremony -->
         <article class="event-card">
           <div class="icon">
-            <img src="assets/images/IMG_2171.jpeg" alt="Wedding Ceremony photo" />
+            <img src="assets/images/icons/ceremony.svg" alt="Wedding ceremony icon" />
           </div>
           <div class="details">
             <div class="time">
@@ -88,7 +88,7 @@
         <!-- Reception -->
         <article class="event-card">
           <div class="icon">
-            <img src="assets/images/IMG_2174.png" alt="Reception photo" />
+            <img src="assets/images/icons/reception.svg" alt="Reception icon" />
           </div>
           <div class="details">
             <div class="time">
@@ -102,7 +102,7 @@
         <!-- After Party -->
         <article class="event-card">
           <div class="icon">
-            <img src="assets/images/IMG_2169.jpeg" alt="After Party photo" />
+            <img src="assets/images/icons/after-party.svg" alt="After party icon" />
           </div>
           <div class="details">
             <div class="time">
@@ -118,7 +118,7 @@
         <!-- Farewell Cookout -->
         <article class="event-card">
           <div class="icon">
-            <img src="assets/images/IMG_2170.jpeg" alt="Farewell Cookout photo" />
+            <img src="assets/images/icons/farewell-cookout.svg" alt="Farewell cookout icon" />
           </div>
           <div class="details">
             <div class="time">
@@ -134,7 +134,7 @@
         <!-- For Those Still Around -->
         <article class="event-card">
           <div class="icon">
-            <img src="assets/images/IMG_2171.jpeg" alt="Monday photo" />
+            <img src="assets/images/icons/bonus-day.svg" alt="Extra day icon" />
           </div>
           <div class="details">
             <div class="time">


### PR DESCRIPTION
## Summary
- Replace photo placeholders on the events page with custom SVG icons for each event.
- Provide dedicated icons for welcome party, brunch, outdoor ceremony, reception, after party, cookout, and extra day.

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68904fa8aa10832eb88003c4cc34c5c7