### PR TITLE
Enhance gallery interactions and tidy styles

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -62,6 +62,15 @@
   object-fit: cover;
   border-radius: var(--card-radius);
   cursor: pointer;
+  transition:
+    transform var(--t-fast) var(--ease),
+    box-shadow var(--t-fast) var(--ease);
+}
+
+.gallery-grid img:hover,
+.gallery-grid img:focus {
+  transform: scale(1.03);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
 }
 
 /* ── Sticky Header ── */

--- a/assets/css/theme.css
+++ b/assets/css/theme.css
@@ -21,6 +21,7 @@
   /* transitions */
   --t-fast: 0.18s;
   --t-med: 0.7s;
+  --ease: ease;
   --ease-med: ease;
 }
 

--- a/assets/js/gallery.js
+++ b/assets/js/gallery.js
@@ -43,6 +43,7 @@ document.addEventListener("DOMContentLoaded", () => {
       const img = document.createElement("img");
       img.src = src;
       img.alt = `Photo ${idx + 1}`;
+      img.loading = "lazy";
       img.dataset.index = idx;
       grid.appendChild(img);
     });


### PR DESCRIPTION
## Summary
- Smoothly scale and shadow gallery images on hover for a subtle visual boost
- Define missing `--ease` variable for consistent transitions
- Lazy-load gallery thumbnails for lighter page loads

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68905267b2b4832ebd16a9cab14d72ec