### PR TITLE
Center events and reorder details

### DIFF
--- a/assets/css/events.css
+++ b/assets/css/events.css
@@ -7,20 +7,24 @@
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
+  align-items: center;
 }
 
 /* Individual event card */
 .event-card {
   display: flex;
-  align-items: flex-start;
-  gap: 1.2rem;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 0.6rem;
 }
 
-/* Icon on the left */
+/* Icon above details */
 .event-card .icon {
   flex-shrink: 0;
   width: 40px;
   height: 40px;
+  margin-bottom: 0.3rem;
 }
 
 /* Icon images or inline SVGs fill the box */
@@ -31,20 +35,23 @@
 }
 
 /* Event details */
-.event-card .details {
-  flex: 1;
-}
-.event-card .time {
-  font-weight: 600;
-  color: var(--emerald-accent);
-  margin-bottom: 0.3rem;
-  font-size: 1.1rem;
-}
 .event-card .title {
   font-family: var(--font-heading);
   font-size: 1.4rem;
-  margin: 0 0 0.5rem;
+  margin: 0 0 0.3rem;
   color: var(--emerald-border);
+}
+.event-card .date,
+.event-card .time {
+  font-weight: 600;
+  color: var(--emerald-accent);
+  font-size: 1.1rem;
+}
+.event-card .date {
+  margin-bottom: 0.2rem;
+}
+.event-card .time {
+  margin-bottom: 0.5rem;
 }
 .event-card .description {
   margin: 0;

--- a/events.html
+++ b/events.html
@@ -41,11 +41,9 @@
             <img src="assets/images/icons/welcome-party.svg" alt="Welcome party icon" />
           </div>
           <div class="details">
-            <div class="time">
-              Friday, September 11, 2026&nbsp;·&nbsp;6:00&nbsp;PM –
-              10:00&nbsp;PM
-            </div>
             <h2 class="title">Welcome Party</h2>
+            <div class="date">Friday, September 11, 2026</div>
+            <div class="time">6:00&nbsp;PM – 10:00&nbsp;PM</div>
             <p class="description">
               Kick off the celebration with drinks and light bites.
             </p>
@@ -58,11 +56,9 @@
             <img src="assets/images/icons/mimosa-brunch.svg" alt="Mimosa brunch icon" />
           </div>
           <div class="details">
-            <div class="time">
-              Saturday, September 12, 2026&nbsp;·&nbsp;11:00&nbsp;AM –
-              2:00&nbsp;PM
-            </div>
             <h2 class="title">Mimosa Brunch</h2>
+            <div class="date">Saturday, September 12, 2026</div>
+            <div class="time">11:00&nbsp;AM – 2:00&nbsp;PM</div>
             <p class="description">
               Ease into the day with mimosas and a casual brunch.
             </p>
@@ -75,10 +71,9 @@
             <img src="assets/images/icons/ceremony.svg" alt="Wedding ceremony icon" />
           </div>
           <div class="details">
-            <div class="time">
-              Saturday, September 12, 2026&nbsp;·&nbsp;5:00&nbsp;PM
-            </div>
             <h2 class="title">Wedding Ceremony</h2>
+            <div class="date">Saturday, September 12, 2026</div>
+            <div class="time">5:00&nbsp;PM</div>
             <p class="description">
               Join us beneath the willow tree in the Rose Garden for the
               ceremony.
@@ -92,10 +87,9 @@
             <img src="assets/images/icons/reception.svg" alt="Reception icon" />
           </div>
           <div class="details">
-            <div class="time">
-              Saturday, September 12, 2026&nbsp;·&nbsp;7:00&nbsp;PM
-            </div>
             <h2 class="title">Reception</h2>
+            <div class="date">Saturday, September 12, 2026</div>
+            <div class="time">7:00&nbsp;PM</div>
             <p class="description">Dinner and dancing in the Barn Hall.</p>
           </div>
         </article>
@@ -106,10 +100,9 @@
             <img src="assets/images/icons/after-party.svg" alt="After party icon" />
           </div>
           <div class="details">
-            <div class="time">
-              Saturday, September 12, 2026&nbsp;·&nbsp;12:00&nbsp;AM
-            </div>
             <h2 class="title">After Party</h2>
+            <div class="date">Saturday, September 12, 2026</div>
+            <div class="time">12:00&nbsp;AM</div>
             <p class="description">
               Keep the celebration going with late-night snacks and music.
             </p>
@@ -122,10 +115,9 @@
             <img src="assets/images/icons/farewell-cookout.svg" alt="Farewell cookout icon" />
           </div>
           <div class="details">
-            <div class="time">
-              Sunday, September 13, 2026&nbsp;·&nbsp;Time&nbsp;TBD
-            </div>
             <h2 class="title">Farewell Cookout</h2>
+            <div class="date">Sunday, September 13, 2026</div>
+            <div class="time">Time&nbsp;TBD</div>
             <p class="description">
               Wrap up the weekend with a casual cookout.
             </p>
@@ -138,10 +130,9 @@
             <img src="assets/images/icons/bonus-day.svg" alt="Extra day icon" />
           </div>
           <div class="details">
-            <div class="time">
-              Monday, September 14, 2026&nbsp;·&nbsp;Time&nbsp;TBD
-            </div>
             <h2 class="title">For Those Still Around</h2>
+            <div class="date">Monday, September 14, 2026</div>
+            <div class="time">Time&nbsp;TBD</div>
             <p class="description">
               We'll figure out a fun activity for anyone still in town.
             </p>


### PR DESCRIPTION
## Summary
- Center the events list and each event card for a symmetrical layout
- Show event title before its date, time and description

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689118f7c7b4832eae95afdfab6d1451