### PR TITLE
Add cocktail hour event and icon

### DIFF
--- a/assets/images/icons/cocktail-hour.svg
+++ b/assets/images/icons/cocktail-hour.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" stroke="#014421" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M12 12h40"/>
+  <path d="M12 12l20 20 20-20"/>
+  <path d="M32 32v20"/>
+  <path d="M24 52h16"/>
+  <circle cx="44" cy="20" r="4"/>
+</svg>

--- a/events.html
+++ b/events.html
@@ -81,6 +81,24 @@
           </div>
         </article>
 
+        <!-- Cocktail Hour -->
+        <article class="event-card">
+          <div class="icon">
+            <img
+              src="assets/images/icons/cocktail-hour.svg"
+              alt="Cocktail hour icon"
+            />
+          </div>
+          <div class="details">
+            <h2 class="title">Cocktail Hour</h2>
+            <div class="date">Saturday, September 12, 2026</div>
+            <div class="time">6:00&nbsp;PM – 7:00&nbsp;PM</div>
+            <p class="description">
+              Sip and mingle while we transition to the reception.
+            </p>
+          </div>
+        </article>
+
         <!-- Reception -->
         <article class="event-card">
           <div class="icon">


### PR DESCRIPTION
## Summary
- insert cocktail hour event after the ceremony with timing and description
- add matching cocktail-hour SVG icon

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689127335e3c832e954b978a89b33e8c