### PR TITLE
Refine attire color palette and tagline

### DIFF
--- a/assets/css/attire.css
+++ b/assets/css/attire.css
@@ -79,6 +79,20 @@
   margin: 2rem 0;
 }
 
+.palette-group {
+  margin-top: 1.5rem;
+}
+
+.palette-group h3 {
+  font-size: 1.2rem;
+  color: var(--emerald-accent);
+  margin-bottom: 0.5rem;
+}
+
+.palette-note {
+  margin-top: 0.5rem;
+}
+
 .palette {
   display: flex;
   justify-content: center;

--- a/attire.html
+++ b/attire.html
@@ -35,15 +35,15 @@
       <h1>Guest Attire</h1>
 
       <section class="dress-guide">
-        <h2>Dress Code: Elegant. Classy. Chic.</h2>
+        <h2>Elegant. Classy. Chic.</h2>
         <p>
           <strong
             >We can't wait to celebrate and dance the night away with
             you!</strong
           ><br ><br>To help make the evening feel as special as it is, we kindly
           ask that you join us in dressing to impress. Please align with our
-          suggested dress code and color palette—think chic, elegant, and
-          elevated neutrals. Let’s make it a stylish night to remember!
+          suggested color palette—think chic, elegant, and elevated neutrals.
+          Let’s make it a stylish night to remember!
         </p>
         <p>
           <em
@@ -56,12 +56,21 @@
 
       <section class="color-palette">
         <h2>Color Palette</h2>
-        <div class="palette">
-          <span class="color-circle black"></span>
-          <span class="color-circle gray"></span>
-          <span class="color-circle brown"></span>
-          <span class="color-circle gold"></span>
-          <span class="color-circle tan"></span>
+        <div class="palette-group">
+          <h3>Preferred</h3>
+          <div class="palette">
+            <span class="color-circle black"></span>
+            <span class="color-circle gray"></span>
+          </div>
+          <p class="palette-note"><small><em>Black tie preferred</em></small></p>
+        </div>
+        <div class="palette-group">
+          <h3>Other Options</h3>
+          <div class="palette">
+            <span class="color-circle brown"></span>
+            <span class="color-circle gold"></span>
+            <span class="color-circle tan"></span>
+          </div>
         </div>
       </section>
 


### PR DESCRIPTION
## Summary
- Drop "Dress Code" wording in attire tagline
- Split attire color palette into preferred and other options with black tie note
- Clarify color guidance text

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689127a8b28c832e92ac6739edc4d32a