### PR TITLE
Use PNG map image on events page

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -208,7 +208,8 @@ body {
   border-radius: var(--card-radius);
   box-shadow: 0 4px 24px rgba(0, 0, 0, 0.1);
 }
-.iframe-container iframe {
+.iframe-container iframe,
+.iframe-container img {
   position: absolute;
   top: 0;
   left: 0;
@@ -339,7 +340,8 @@ body {
   max-width: 90%;
   width: 90%;
 }
-.pdf-overlay iframe {
+.pdf-overlay iframe,
+.pdf-overlay img {
   width: 100%;
   height: 80vh;
   border: 0;

--- a/events.html
+++ b/events.html
@@ -162,17 +162,15 @@
       <section class="map-section">
         <h2>Venue Map & Directions</h2>
         <div class="iframe-container">
-          <iframe
+          <img
             src="assets/images/venue_events.png"
-            aria-label="Venue Map"
-            title="Venue Map"
-            frameborder="0"
-          ></iframe>
+            alt="Venue map"
+          />
           <div class="map-trigger" aria-label="Open map"></div>
         </div>
         <p class="description">
           Valet parking is available at the main entrance off Oak Avenue. For
-          GPS, enter 123 Country Lane. Consult the PDF map below for detailed
+          GPS, enter 123 Country Lane. Consult the map below for detailed
           directions.
         </p>
       </section>
@@ -181,7 +179,7 @@
     <div id="mapOverlay" class="pdf-overlay hidden">
       <div class="pdf-content">
         <button class="close" aria-label="Close">&times;</button>
-        <iframe src="assets/images/venue_events.png" title="Venue Map"></iframe>
+        <img src="assets/images/venue_events.png" alt="Venue map" />
       </div>
     </div>
 


### PR DESCRIPTION
## Summary
- Show event venue map as a PNG image instead of an iframe
- Update copy to remove PDF reference
- Support images in responsive container and overlay styles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68916e9c842c832eaf64dbd8921506b0