### PR TITLE
Fix map image distortion on events page

### DIFF
--- a/assets/css/events.css
+++ b/assets/css/events.css
@@ -70,7 +70,14 @@
 
 /* Responsive iframe container for map */
 .iframe-container {
-  padding-bottom: 56.25%; /* 16:9 aspect ratio */
+  padding-bottom: 0; /* allow natural height for images */
+}
+
+/* Ensure map images keep their aspect ratio */
+.iframe-container img {
+  position: static;
+  width: 100%;
+  height: auto;
 }
 
 /* Mobile tweaks */

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -343,9 +343,17 @@ body {
 .pdf-overlay iframe,
 .pdf-overlay img {
   width: 100%;
-  height: 80vh;
   border: 0;
   border-radius: var(--card-radius);
+}
+
+.pdf-overlay iframe {
+  height: 80vh;
+}
+
+.pdf-overlay img {
+  height: auto;
+  max-height: 80vh;
 }
 .pdf-overlay .close {
   position: absolute;


### PR DESCRIPTION
## Summary
- prevent schedule map on Events page from stretching by allowing natural image height
- ensure overlay map images maintain aspect ratio and max viewport height

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6891752d2ef4832e9dfde3ea5d252c90