### PR TITLE
Fix map overlay image distortion

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -342,17 +342,19 @@ body {
 }
 .pdf-overlay iframe,
 .pdf-overlay img {
-  width: 100%;
   border: 0;
   border-radius: var(--card-radius);
 }
 
 .pdf-overlay iframe {
+  width: 100%;
   height: 80vh;
 }
 
 .pdf-overlay img {
+  width: auto;
   height: auto;
+  max-width: 100%;
   max-height: 80vh;
 }
 .pdf-overlay .close {


### PR DESCRIPTION
## Summary
- prevent distortion by allowing map overlay images to scale within viewport

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68918644e404832e90ca1158592096fa