### PR TITLE
Remove map overlay click from events page

### DIFF
--- a/events.html
+++ b/events.html
@@ -166,7 +166,6 @@
             src="assets/images/venue_events.png"
             alt="Venue map"
           />
-          <div class="map-trigger" aria-label="Open map"></div>
         </div>
         <p class="description">
           Valet parking is available at the main entrance off Oak Avenue. For
@@ -175,13 +174,6 @@
         </p>
       </section>
     </main>
-
-    <div id="mapOverlay" class="pdf-overlay hidden">
-      <div class="pdf-content">
-        <button class="close" aria-label="Close">&times;</button>
-        <img src="assets/images/venue_events.png" alt="Venue map" />
-      </div>
-    </div>
 
     <!-- Site‑wide behaviors -->
     <script src="assets/js/script.js"></script>


### PR DESCRIPTION
## Summary
- Make the Events page venue map a static image by removing the clickable overlay and its associated overlay element.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689188fa4ee4832ebe264bf02db97866