### PR TITLE
feat: unify button styling across pages

### DIFF
--- a/assets/css/home.css
+++ b/assets/css/home.css
@@ -39,34 +39,6 @@
     padding: 0.7rem 2rem;
   }
 }
-
-/* Centered button rows on home page */
-.text-page-buttons {
-  text-align: center;
-  margin: 1.5rem 0;
-}
-
-.text-page-buttons .home-btn {
-  display: inline-block;
-  padding: 1rem 3rem;
-  font-size: 1.4rem;
-  background: var(--bg-emerald-dark);
-  color: var(--white);
-  border: 2px solid var(--emerald-border);
-}
-
-.text-page-buttons .home-btn:hover {
-  background: var(--emerald-hover);
-  color: var(--white);
-}
-
-@media (max-width: 600px) {
-  .text-page-buttons .home-btn {
-    font-size: 1.2rem;
-    padding: 0.9rem 2.5rem;
-  }
-}
-
 /* Adjust spacing for subheading */
 .content-container h1 + h2 {
   margin-top: 0.5rem;

--- a/assets/css/registry.css
+++ b/assets/css/registry.css
@@ -7,34 +7,9 @@
   line-height: 1.6;
 }
 
-/* Centered registry button and icon */
-.registry-link {
-  text-align: center;
-  margin-top: 1.5rem;
-}
-
 .registry-icon {
   display: block;
   margin: 0 auto 1.5rem;
   width: 80px;
   height: auto;
-}
-
-.registry-btn {
-  display: inline-block;
-  padding: 1rem 3rem;
-  font-size: 1.4rem;
-}
-
-.registry-btn:hover {
-  background: var(--emerald-hover);
-  color: var(--white);
-}
-
-/* Mobile tweak */
-@media (max-width: 600px) {
-  .registry-btn {
-    font-size: 1.2rem;
-    padding: 0.9rem 2.5rem;
-  }
 }

--- a/assets/css/theme.css
+++ b/assets/css/theme.css
@@ -89,6 +89,9 @@ body {
 /* buttons share the same structure as cards but use the
    site background color for their fill */
 .main-btn {
+  display: inline-block;
+  padding: 1rem 3rem;
+  font-size: 1.4rem;
   background: var(--bg-emerald-dark);
   color: var(--white);
   border-radius: var(--btn-radius);
@@ -102,6 +105,23 @@ body {
     color var(--t-fast) var(--ease-med),
     transform var(--t-fast) var(--ease-med),
     opacity var(--t-med) var(--ease-med);
+}
+
+.main-btn:hover {
+  background: var(--emerald-hover);
+  color: var(--white);
+}
+
+@media (max-width: 600px) {
+  .main-btn {
+    font-size: 1.2rem;
+    padding: 0.9rem 2.5rem;
+  }
+}
+
+.text-page-buttons {
+  text-align: center;
+  margin: 1.5rem 0;
 }
 
 /* fade utility */

--- a/home.html
+++ b/home.html
@@ -49,12 +49,12 @@
         haven't done so already please make sure you submit your RSVP.
       </p>
       <div class="text-page-buttons">
-        <a href="rsvp.html" class="main-btn home-btn">RSVP</a>
+        <a href="rsvp.html" class="main-btn">RSVP</a>
       </div>
 
       <p>Check out the fun story of how we met each other</p>
       <div class="text-page-buttons">
-        <a href="our-story.html" class="main-btn home-btn">Our Story</a>
+        <a href="our-story.html" class="main-btn">Our Story</a>
       </div>
       <p>
         Most importantly, get familiar with our site and its navigation.

--- a/registry.html
+++ b/registry.html
@@ -38,7 +38,7 @@
         gift of all. If you'd like to honor us with a gift, anything is
         appreciated although not required. Please visit our registry below.
       </p>
-      <div class="registry-link">
+      <div class="text-page-buttons">
         <img
           src="assets/images/icons/gift.svg"
           alt="gift icon"
@@ -46,7 +46,7 @@
         />
         <a
           href="https://www.myregistry.com/giftlist/becomingcummings"
-          class="main-btn registry-btn"
+          class="main-btn"
           target="_blank"
           rel="noopener"
           >View Our Registry</a


### PR DESCRIPTION
## Summary
- centralize button styles in theme.css with shared layout helpers
- update home and registry pages to use the shared button style
- trim redundant button rules from page-specific CSS

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68919f2a08c0832e9882ae79bcb0ccaf