### PR TITLE
feat: enlarge main button for readability

### DIFF
--- a/assets/css/story.css
+++ b/assets/css/story.css
@@ -161,8 +161,8 @@
   margin-top: 1.5rem;
 }
 .flip-controls .main-btn {
-  padding: 0.6rem 1.6rem;
-  font-size: 1rem;
+  padding: 0.8rem 2rem;
+  font-size: 1.2rem;
 }
 
 #flipbook {

--- a/assets/css/theme.css
+++ b/assets/css/theme.css
@@ -90,8 +90,9 @@ body {
    site background color for their fill */
 .main-btn {
   display: inline-block;
-  padding: 1rem 3rem;
-  font-size: 1.4rem;
+  padding: 1.2rem 3.5rem;
+  font-size: 1.6rem;
+  font-weight: 700;
   background: var(--bg-emerald-dark);
   color: var(--white);
   border-radius: var(--btn-radius);
@@ -114,8 +115,8 @@ body {
 
 @media (max-width: 600px) {
   .main-btn {
-    font-size: 1.2rem;
-    padding: 0.9rem 2.5rem;
+    font-size: 1.3rem;
+    padding: 1rem 3rem;
   }
 }
 


### PR DESCRIPTION
## Summary
- enlarge main button padding, font size, and weight for better readability
- scale up button size in mobile view
- increase flipbook navigation button size

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891a47a6164832e845efffa81c44dbb