### PR TITLE
Ensure main buttons retain white text color

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -172,11 +172,11 @@ body {
 }
 
 /* Links */
-.content-container a {
+.content-container a:not(.main-btn) {
   color: var(--emerald-accent);
   text-decoration: underline;
 }
-.content-container a:hover {
+.content-container a:not(.main-btn):hover {
   color: var(--emerald-border);
 }
 


### PR DESCRIPTION
## Summary
- prevent content-container anchor styles from overriding main-btn color

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891a910483c832eb747f0fb18dc44d2