### PR TITLE
Clean up meta tags and harden external links

### DIFF
--- a/faqs.html
+++ b/faqs.html
@@ -2,10 +2,9 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta
       name="viewport"
-      content="width=device-width, initial-scale=1, maximum-scale=1"
+      content="width=device-width, initial-scale=1"
     />
     <title>FAQs</title>
     <link rel="icon" href="assets/images/favicon.png" type="image/png" />

--- a/gallery.html
+++ b/gallery.html
@@ -2,10 +2,9 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta
       name="viewport"
-      content="width=device-width, initial-scale=1, maximum-scale=1"
+      content="width=device-width, initial-scale=1"
     />
     <title>Gallery</title>
     <link rel="icon" type="image/png" href="assets/images/favicon.png" />

--- a/home.html
+++ b/home.html
@@ -2,10 +2,9 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta
       name="viewport"
-      content="width=device-width, initial-scale=1, maximum-scale=1"
+      content="width=device-width, initial-scale=1"
     />
     <title>Home</title>
     <link rel="icon" type="image/png" href="assets/images/favicon.png" />

--- a/index.html
+++ b/index.html
@@ -2,11 +2,10 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1, maximum-scale=1"
-    />
+      <meta
+        name="viewport"
+        content="width=device-width, initial-scale=1"
+      />
     <title>Home</title>
     <link rel="icon" type="image/png" href="assets/images/favicon.png" />
 

--- a/our-story.html
+++ b/our-story.html
@@ -2,10 +2,9 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta
       name="viewport"
-      content="width=device-width, initial-scale=1, maximum-scale=1"
+      content="width=device-width, initial-scale=1"
     />
     <title>Our Story</title>
     <link rel="icon" type="image/png" href="assets/images/favicon.png" />

--- a/registry.html
+++ b/registry.html
@@ -45,10 +45,10 @@
           class="registry-icon"
         />
         <a
-          href="https://www.myregistry.com/giftlist/becomingcummings"
-          class="main-btn"
-          target="_blank"
-          rel="noopener"
+            href="https://www.myregistry.com/giftlist/becomingcummings"
+            class="main-btn"
+            target="_blank"
+            rel="noopener noreferrer"
           >View Our Registry</a
         >
       </div>

--- a/travel.html
+++ b/travel.html
@@ -2,10 +2,9 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta
       name="viewport"
-      content="width=device-width, initial-scale=1, maximum-scale=1"
+      content="width=device-width, initial-scale=1"
     />
     <title>Travel</title>
     <link rel="icon" href="assets/images/favicon.png" type="image/png" />
@@ -39,9 +38,9 @@
           Reno‑Tahoe International Airport is a 50‑minute drive away. We
           recommend renting a car— consider coordinating rides with friends.
           <a
-            href="http://www.renoairport.com/tofrom-airport/rental-cars"
-            target="_blank"
-            rel="noopener"
+              href="https://www.renoairport.com/tofrom-airport/rental-cars"
+              target="_blank"
+              rel="noopener noreferrer"
           >
             Rental Car Info </a
           >.
@@ -95,9 +94,9 @@
           <li>
             Visit our custom booking page by clicking
             <a
-              href="https://www.chaletview.com/booking"
-              target="_blank"
-              rel="noopener"
+                href="https://www.chaletview.com/booking"
+                target="_blank"
+                rel="noopener noreferrer"
             >
               HERE </a
             >.


### PR DESCRIPTION
## Summary
- simplify viewport tags and drop legacy `X-UA-Compatible` headers across pages
- use HTTPS and `rel="noopener noreferrer"` for external links

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891aad8e4f8832e878f9d5347a811e9