### PR TITLE
Shrink events map container to image height

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -894,13 +894,13 @@ body {
   margin-top: 1rem;
 }
 
-/* Responsive iframe container for map */
-.iframe-container {
+/* Container for static map images */
+.iframe-container.img-only {
   padding-bottom: 0; /* allow natural height for images */
 }
 
 /* Ensure map images keep their aspect ratio */
-.iframe-container img {
+.iframe-container.img-only img {
   position: static;
   width: 100%;
   height: auto;

--- a/events.html
+++ b/events.html
@@ -158,7 +158,7 @@
       <!-- Map & Directions -->
       <section class="map-section">
         <h2>Venue Map & Directions</h2>
-        <div class="iframe-container">
+        <div class="iframe-container img-only">
           <img
             src="assets/images/venue_events.png"
             alt="Venue map"


### PR DESCRIPTION
## Summary
- Prevent static map images from inheriting 16:9 padding by introducing a dedicated `img-only` container style.
- Apply the new `img-only` class to the Events page map so the image only takes up necessary space.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891b406c470832ea1d4e863af0df516