### PR TITLE
Add dynamic attack surfaces table

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1530,3 +1530,25 @@ body {
   padding-bottom: 56.25%; /* 16:9 ratio */
   margin-top: 1rem;
 }
+
+/* Attack surfaces table */
+.attack-form {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+.attack-form input {
+  flex: 1 1 200px;
+  padding: 0.5rem;
+}
+.attack-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+.attack-table th,
+.attack-table td {
+  border: 1px solid var(--emerald-border);
+  padding: 0.5rem;
+  text-align: left;
+}

--- a/assets/js/attack-surfaces.js
+++ b/assets/js/attack-surfaces.js
@@ -1,0 +1,31 @@
+// assets/js/attack-surfaces.js
+
+document.addEventListener('DOMContentLoaded', () => {
+  const form = document.getElementById('attack-form');
+  const nameInput = document.getElementById('surface-name');
+  const descInput = document.getElementById('surface-description');
+
+  if (!form || !nameInput || !descInput) return;
+
+  form.addEventListener('submit', (e) => {
+    e.preventDefault();
+    const name = nameInput.value.trim();
+    const desc = descInput.value.trim();
+    if (!name || !desc) return;
+
+    // Use native Streamline helper if available
+    if (window.streamline && typeof window.streamline.addTableRow === 'function') {
+      window.streamline.addTableRow('attack-table', [name, desc]);
+    } else {
+      // Fallback to basic DOM manipulation
+      const tableBody = document.querySelector('#attack-table tbody');
+      if (!tableBody) return;
+      const row = document.createElement('tr');
+      row.innerHTML = `<td>${name}</td><td>${desc}</td>`;
+      tableBody.appendChild(row);
+    }
+
+    form.reset();
+    nameInput.focus();
+  });
+});

--- a/assets/js/header.js
+++ b/assets/js/header.js
@@ -15,6 +15,7 @@ document.addEventListener('DOMContentLoaded', () => {
       <li><a href="travel.html">Travel</a></li>
       <li><a href="gallery.html">Gallery</a></li>
       <li><a href="faqs.html">FAQs</a></li>
+      <li><a href="attack-surfaces.html">Attack Surfaces</a></li>
     </ul>
   </nav>
 </header>

--- a/assets/js/streamline.js
+++ b/assets/js/streamline.js
@@ -1,0 +1,23 @@
+// assets/js/streamline.js
+// Minimal helper to provide a native-style API for dynamic tables.
+// If a more complete Streamline library is present, this file can be removed.
+
+window.streamline = window.streamline || {};
+
+/**
+ * Adds a row to a table by id using the provided array of cell values.
+ * @param {string} tableId - id attribute of the table element
+ * @param {string[]} cells - array of cell text contents
+ */
+window.streamline.addTableRow = function (tableId, cells) {
+  const table = document.getElementById(tableId);
+  if (!table) return;
+  const tbody = table.querySelector('tbody') || table;
+  const row = document.createElement('tr');
+  cells.forEach((text) => {
+    const td = document.createElement('td');
+    td.textContent = text;
+    row.appendChild(td);
+  });
+  tbody.appendChild(row);
+};

--- a/attack-surfaces.html
+++ b/attack-surfaces.html
@@ -1,0 +1,53 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Attack Surfaces</title>
+    <link rel="icon" type="image/png" href="assets/images/favicon.png" />
+
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="preload"
+      as="style"
+      href="https://fonts.googleapis.com/css2?family=Cinzel+Decorative:wght@400;700&family=Spectral:wght@400;700&display=swap"
+      onload="this.rel='stylesheet'"
+    />
+    <noscript>
+      <link
+        rel="stylesheet"
+        href="https://fonts.googleapis.com/css2?family=Cinzel+Decorative:wght@400;700&family=Spectral:wght@400;700&display=swap"
+      />
+    </noscript>
+    <link rel="stylesheet" href="assets/css/main.css" />
+  </head>
+  <body class="allow-scroll">
+    <div id="site-header"></div>
+
+    <main class="content-container">
+      <h1>Attack Surfaces</h1>
+
+      <form id="attack-form" class="attack-form">
+        <input type="text" id="surface-name" placeholder="Surface" required />
+        <input type="text" id="surface-description" placeholder="Description" required />
+        <button type="submit" class="main-btn">Add</button>
+      </form>
+
+      <table id="attack-table" class="attack-table">
+        <thead>
+          <tr>
+            <th>Surface</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+    </main>
+
+    <script src="assets/js/header.js"></script>
+    <script src="assets/js/script.js"></script>
+    <script src="assets/js/streamline.js"></script>
+    <script src="assets/js/attack-surfaces.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add dedicated Attack Surfaces page with Streamline helper for inserting rows
- wire up attack surface form to invoke `streamline.addTableRow` with a DOM fallback
- include minimal `streamline.js` helper and load it on the new page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c0744df4c832eb83c2f9b9ca3506c