### PR TITLE
Add RSVP test page with unique code lookup

### DIFF
--- a/assets/guests.json
+++ b/assets/guests.json
@@ -1,0 +1,7 @@
+[
+  {"name": "Alice Smith", "code": "48291"},
+  {"name": "Bob Johnson", "code": "17530"},
+  {"name": "Carlos Ruiz", "code": "90812"},
+  {"name": "Diana Liu", "code": "56347"},
+  {"name": "Ethan Patel", "code": "34920"}
+]

--- a/assets/js/rsvp-test.js
+++ b/assets/js/rsvp-test.js
@@ -1,0 +1,29 @@
+// assets/js/rsvp-test.js
+
+document.addEventListener('DOMContentLoaded', () => {
+  const form = document.getElementById('lookup-form');
+  const input = document.getElementById('code-input');
+  const info = document.getElementById('guest-info');
+
+  if (!form || !input || !info) return;
+
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const code = input.value.trim();
+    if (!code) return;
+
+    try {
+      const response = await fetch('assets/guests.json');
+      const guests = await response.json();
+      const guest = guests.find((g) => g.code === code);
+      if (guest) {
+        info.textContent = `Welcome, ${guest.name}!`;
+      } else {
+        info.textContent = 'Code not found.';
+      }
+    } catch (err) {
+      info.textContent = 'Unable to lookup guest.';
+      console.error(err);
+    }
+  });
+});

--- a/rsvp-test.html
+++ b/rsvp-test.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>RSVP Test</title>
+    <link rel="icon" href="assets/images/favicon.png" type="image/png" />
+
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="preload"
+      as="style"
+      href="https://fonts.googleapis.com/css2?family=Cinzel+Decorative:wght@400;700&family=Spectral:wght@400;700&display=swap"
+      onload="this.rel='stylesheet'"
+    />
+    <noscript>
+      <link
+        rel="stylesheet"
+        href="https://fonts.googleapis.com/css2?family=Cinzel+Decorative:wght@400;700&family=Spectral:wght@400;700&display=swap"
+      />
+    </noscript>
+    <link rel="stylesheet" href="assets/css/main.css" />
+  </head>
+  <body class="allow-scroll">
+    <!-- ── Sticky Header & Nav ── -->
+    <div id="site-header"></div>
+
+    <!-- ── Content Card ── -->
+    <main class="content-container">
+      <h1 class="page-title">RSVP Lookup</h1>
+      <form id="lookup-form" class="rsvp-form">
+        <label for="code-input">Enter your 5-digit code:</label>
+        <input
+          type="text"
+          id="code-input"
+          pattern="\d{5}"
+          maxlength="5"
+          required
+        />
+        <button type="submit">Lookup</button>
+      </form>
+      <div id="guest-info" class="guest-info"></div>
+    </main>
+
+    <!-- site-wide behaviors -->
+    <script src="assets/js/header.js"></script>
+    <script src="assets/js/script.js"></script>
+    <script src="assets/js/rsvp-test.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- restore original RSVP page with embedded Aisle Planner iframe
- add `rsvp-test.html` page for testing code-based lookups
- provide `rsvp-test.js` to fetch `assets/guests.json` and display guest info

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a9579464b0832e8a294d0b140a3a2e