### PR TITLE
Enhance RSVP test layout with meal gating and decline option

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1530,3 +1530,36 @@ body {
   padding-bottom: 56.25%; /* 16:9 ratio */
   margin-top: 1rem;
 }
+
+/* RSVP test layout */
+.guest {
+  margin-bottom: 1rem;
+}
+.guest .event-grid {
+  display: grid;
+  grid-template-columns: auto auto;
+  grid-template-rows: repeat(3, auto);
+  column-gap: 1rem;
+  row-gap: 0.5rem;
+}
+.guest .event-grid .event-option {
+  grid-column: 1;
+}
+.guest .event-grid .event-option:nth-of-type(1) {
+  grid-row: 1;
+}
+.guest .event-grid .event-option:nth-of-type(2) {
+  grid-row: 2;
+}
+.guest .event-grid .event-option:nth-of-type(3) {
+  grid-row: 3;
+}
+.guest .event-grid .meal-option {
+  grid-column: 2;
+  grid-row: 2;
+  align-self: center;
+}
+#apply-all,
+#decline-all {
+  margin: 0.5rem 0;
+}

--- a/assets/js/rsvp-test.js
+++ b/assets/js/rsvp-test.js
@@ -48,20 +48,37 @@ document.addEventListener('DOMContentLoaded', () => {
       personDiv.className = 'guest';
       personDiv.innerHTML = `
         <legend>Guest ${i + 1}</legend>
-        <label><input type="checkbox" name="guest${i}-ceremony"> Ceremony</label>
-        <label><input type="checkbox" name="guest${i}-reception"> Reception</label>
-        <label><input type="checkbox" name="guest${i}-farewell"> Farewell</label>
-        <label>Meal:
-          <select name="guest${i}-meal">
-            <option value="">Select</option>
-            <option>Chicken</option>
-            <option>Beef</option>
-            <option>Veg</option>
-          </select>
-        </label>
+        <div class="event-grid">
+          <label class="event-option"><input type="checkbox" name="guest${i}-ceremony"> Ceremony</label>
+          <label class="event-option"><input type="checkbox" name="guest${i}-reception"> Reception</label>
+          <label class="event-option"><input type="checkbox" name="guest${i}-farewell"> Farewell</label>
+          <div class="meal-option">
+            <label>Meal:
+              <select name="guest${i}-meal" disabled>
+                <option value="">Select</option>
+                <option>Chicken</option>
+                <option>Beef</option>
+                <option>Veg</option>
+              </select>
+            </label>
+          </div>
+        </div>
       `;
       container.appendChild(personDiv);
+
+      const reception = personDiv.querySelector(`input[name="guest${i}-reception"]`);
+      const mealSelect = personDiv.querySelector(`select[name="guest${i}-meal"]`);
+      reception.addEventListener('change', () => {
+        mealSelect.disabled = !reception.checked;
+        if (!reception.checked) mealSelect.value = '';
+      });
     }
+
+    const declineBtn = document.createElement('button');
+    declineBtn.type = 'button';
+    declineBtn.id = 'decline-all';
+    declineBtn.textContent = 'Unfortunately, we are unable to attend';
+    container.appendChild(declineBtn);
 
     info.appendChild(container);
 
@@ -79,9 +96,22 @@ document.addEventListener('DOMContentLoaded', () => {
           container.querySelector(`input[name="guest${i}-ceremony"]`).checked = ceremony;
           container.querySelector(`input[name="guest${i}-reception"]`).checked = reception;
           container.querySelector(`input[name="guest${i}-farewell"]`).checked = farewell;
-          container.querySelector(`select[name="guest${i}-meal"]`).value = meal;
+          const mealSelect = container.querySelector(`select[name="guest${i}-meal"]`);
+          mealSelect.value = meal;
+          mealSelect.disabled = !reception;
         }
       });
     }
+
+    declineBtn.addEventListener('click', () => {
+      for (let i = 0; i < size; i++) {
+        ['ceremony', 'reception', 'farewell'].forEach((ev) => {
+          container.querySelector(`input[name="guest${i}-${ev}"]`).checked = false;
+        });
+        const mealSelect = container.querySelector(`select[name="guest${i}-meal"]`);
+        mealSelect.value = '';
+        mealSelect.disabled = true;
+      }
+    });
   }
 });


### PR DESCRIPTION
## Summary
- Arrange RSVP event checkboxes in a single column with meal selection aligned beside the reception option
- Disable meal selection unless reception is checked and add global decline button to clear all selections

## Testing
- ⚠️ `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa51bfd168832ebdd1ba7b5cd1456d