### PR TITLE
Move guest code-based RSVP flow to test page

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -437,8 +437,16 @@ body {
 .hidden {
   display: none;
 }
+.error {
+  color: var(--emerald-accent);
+  margin-top: 0.5rem;
+}
 .fadeable {
   transition: opacity var(--t-med) var(--ease);
+}
+
+.guest-card {
+  margin-bottom: 1rem;
 }
 
 /* Prevent background scroll when overlays are open */

--- a/assets/js/rsvp.js
+++ b/assets/js/rsvp.js
@@ -1,0 +1,140 @@
+// assets/js/rsvp.js
+
+function handleUpdate(res) {
+  console.log(res);
+  const final = document.getElementById('final-message');
+  if (final && res && res.message) {
+    final.textContent = res.message;
+  }
+}
+
+const apiBase = 'https://script.google.com/macros/s/AKfycbxWH3YLiS4PGTM8wMGEqZMgrqzAT1DjvmpB6ejmDYhEP5TitSxoVP1A5rHhR-584n7XbA/exe';
+
+function rsvpNo(code) {
+  const url =
+    apiBase +
+    '?action=update&code=' + encodeURIComponent(code) +
+    '&rsvped=no' +
+    '&callback=handleUpdate';
+  const s = document.createElement('script');
+  s.src = url;
+  document.body.appendChild(s);
+}
+
+function rsvpYes(code, num, chicken, beef, vegetarian) {
+  const url =
+    apiBase +
+    '?action=update&code=' + encodeURIComponent(code) +
+    '&rsvped=yes' +
+    '&number_attending=' + encodeURIComponent(num) +
+    '&chicken=' + encodeURIComponent(chicken) +
+    '&beef=' + encodeURIComponent(beef) +
+    '&vegetarian=' + encodeURIComponent(vegetarian) +
+    '&callback=handleUpdate';
+  const s = document.createElement('script');
+  s.src = url;
+  document.body.appendChild(s);
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  let guests = [];
+  let currentParty = null;
+  let currentCode = '';
+
+  fetch('assets/guests.json')
+    .then((res) => res.json())
+    .then((data) => {
+      guests = data;
+    });
+
+  const stepCode = document.getElementById('step-code');
+  const stepAttending = document.getElementById('step-attending');
+  const stepGuests = document.getElementById('step-guests');
+  const guestCards = document.getElementById('guest-cards');
+  const codeError = document.getElementById('code-error');
+  const mealError = document.getElementById('meal-error');
+  const finalMessage = document.getElementById('final-message');
+
+  document.getElementById('code-submit').addEventListener('click', () => {
+    const input = document.getElementById('code-input');
+    const code = input.value.trim();
+    currentParty = guests.find((g) => g.code === code);
+    if (!currentParty) {
+      codeError.classList.remove('hidden');
+      return;
+    }
+    codeError.classList.add('hidden');
+    currentCode = code;
+    stepCode.classList.add('hidden');
+    stepAttending.classList.remove('hidden');
+  });
+
+  document.getElementById('party-no').addEventListener('click', () => {
+    if (currentCode) rsvpNo(currentCode);
+    stepAttending.classList.add('hidden');
+    finalMessage.textContent = "We'll miss you!";
+    finalMessage.classList.remove('hidden');
+  });
+
+  document.getElementById('party-yes').addEventListener('click', () => {
+    stepAttending.classList.add('hidden');
+    generateGuestCards(currentParty.partySize);
+    stepGuests.classList.remove('hidden');
+  });
+
+  function generateGuestCards(size) {
+    guestCards.innerHTML = '';
+    for (let i = 1; i <= size; i++) {
+      const card = document.createElement('div');
+      card.className = 'guest-card';
+      card.innerHTML = `
+        <label><input type="checkbox" class="attending" checked /> Guest ${i}</label>
+        <select class="meal">
+          <option value="">Select meal</option>
+          <option value="chicken">Chicken</option>
+          <option value="beef">Beef</option>
+          <option value="vegetarian">Vegetarian</option>
+        </select>
+      `;
+      guestCards.appendChild(card);
+    }
+  }
+
+  guestCards.addEventListener('change', (e) => {
+    if (e.target.classList.contains('attending')) {
+      const mealSelect = e.target.closest('.guest-card').querySelector('.meal');
+      mealSelect.disabled = !e.target.checked;
+      if (!e.target.checked) mealSelect.value = '';
+    }
+  });
+
+  stepGuests.addEventListener('submit', (e) => {
+    e.preventDefault();
+    const cards = guestCards.querySelectorAll('.guest-card');
+    let num = 0,
+      chicken = 0,
+      beef = 0,
+      vegetarian = 0,
+      valid = true;
+    cards.forEach((card) => {
+      const attending = card.querySelector('.attending').checked;
+      if (attending) {
+        num++;
+        const meal = card.querySelector('.meal').value;
+        if (!meal) valid = false;
+        if (meal === 'chicken') chicken++;
+        else if (meal === 'beef') beef++;
+        else if (meal === 'vegetarian') vegetarian++;
+      }
+    });
+    if (!valid || num === 0 || num !== chicken + beef + vegetarian) {
+      mealError.classList.remove('hidden');
+      return;
+    }
+    mealError.classList.add('hidden');
+    if (currentCode) rsvpYes(currentCode, num, chicken, beef, vegetarian);
+    stepGuests.classList.add('hidden');
+    finalMessage.textContent = 'Thank you for your RSVP!';
+    finalMessage.classList.remove('hidden');
+  });
+});

--- a/rsvp-test.html
+++ b/rsvp-test.html
@@ -28,45 +28,45 @@
 
     <!-- ── Content Card ── -->
     <main class="content-container">
-      <h1 class="page-title">RSVP JSONP Test</h1>
-      <form id="rsvp-form" class="rsvp-form">
-        <label for="code-input">Enter your 5-digit code:</label>
-        <input type="text" id="code-input" pattern="\d{5}" maxlength="5" required />
-        <label for="num-input">Number attending:</label>
-        <input type="number" id="num-input" min="0" value="0" />
-        <label for="chicken-input">Chicken:</label>
-        <input type="number" id="chicken-input" min="0" value="0" />
-        <label for="beef-input">Beef:</label>
-        <input type="number" id="beef-input" min="0" value="0" />
-        <label for="vegetarian-input">Vegetarian:</label>
-        <input type="number" id="vegetarian-input" min="0" value="0" />
-        <div class="rsvp-choice">
-          <button type="button" id="send-no">RSVP No</button>
-          <button type="button" id="send-yes">RSVP Yes</button>
+      <div class="card intro-card" id="rsvpCard">
+        <div id="step-code">
+          <label for="code-input">Enter your 5-digit code:</label>
+          <input
+            type="text"
+            id="code-input"
+            pattern="\d{5}"
+            maxlength="5"
+            required
+          />
+          <button id="code-submit">Submit</button>
+          <div id="code-error" class="error hidden">
+            Incorrect code. Please try again.
+          </div>
         </div>
-      </form>
-      <div id="guest-info" class="guest-info"></div>
+
+        <div id="step-attending" class="hidden">
+          <p>Is your party attending?</p>
+          <div class="rsvp-choice">
+            <button type="button" id="party-no">No</button>
+            <button type="button" id="party-yes">Yes</button>
+          </div>
+        </div>
+
+        <form id="step-guests" class="hidden">
+          <div id="guest-cards"></div>
+          <div id="meal-error" class="error hidden">
+            Number of meals must equal number of guests attending.
+          </div>
+          <button type="submit">Submit RSVP</button>
+        </form>
+
+        <div id="final-message" class="hidden"></div>
+      </div>
     </main>
 
     <!-- site-wide behaviors -->
     <script src="assets/js/header.js"></script>
     <script src="assets/js/script.js"></script>
-    <script src="assets/js/rsvp-test.js"></script>
-    <script>
-      document.getElementById('send-no').addEventListener('click', () => {
-        const code = document.getElementById('code-input').value.trim();
-        if (code) rsvpNo(code);
-      });
-
-      document.getElementById('send-yes').addEventListener('click', () => {
-        const code = document.getElementById('code-input').value.trim();
-        if (!code) return;
-        const num = document.getElementById('num-input').value || 0;
-        const chicken = document.getElementById('chicken-input').value || 0;
-        const beef = document.getElementById('beef-input').value || 0;
-        const vegetarian = document.getElementById('vegetarian-input').value || 0;
-        rsvpYes(code, num, chicken, beef, vegetarian);
-      });
-    </script>
+    <script src="assets/js/rsvp.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- Restore landing page intro card and remove RSVP form
- Add multi-step RSVP test page with code validation and per-guest meal selection

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68afd570c8a0832e824eb232599dd669