### PR TITLE
Handle nested RSVP API responses

### DIFF
--- a/assets/js/rsvp-test.js
+++ b/assets/js/rsvp-test.js
@@ -2,18 +2,30 @@
 
 function handleUpdate(res) {
   console.log(res);
-  if (finalMessage && res && res.message) {
-    finalMessage.textContent = res.message;
+
+  // Support both flat and nested response shapes (e.g. res.data.message).
+  const ok =
+    (res && res.ok) || (res && res.data && res.data.ok);
+  const payload = res && res.data ? res.data : res;
+
+  if (finalMessage && ok && payload && payload.message) {
+    finalMessage.textContent = payload.message;
   }
 }
 
 function handleValidate(res) {
   console.log(res);
-  if (res && res.partySize) {
+
+  // Support both flat and nested response shapes (e.g. res.data.partySize).
+  const ok =
+    (res && res.ok) || (res && res.data && res.data.ok);
+  const payload = res && res.data ? res.data : res;
+
+  if (ok && payload && payload.partySize) {
     codeError.classList.add('hidden');
     stepCode.classList.add('hidden');
     stepAttending.classList.remove('hidden');
-    partySize = res.partySize;
+    partySize = payload.partySize;
   } else {
     codeError.classList.remove('hidden');
   }


### PR DESCRIPTION
## Summary
- Ensure RSVP callbacks only use message or party size when API returns an ok status
- Support nested data structures in API responses

## Testing
- `npm test` *(fails: ENOENT, could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b000999130832eb1f9922560a542d1