### PR TITLE
Handle missing message in RSVP update

### DIFF
--- a/assets/js/rsvp-test.js
+++ b/assets/js/rsvp-test.js
@@ -1,9 +1,15 @@
 // assets/js/rsvp-test.js
 
 function handleUpdate(res) {
-  console.log(res);
-  if (finalMessage && res && res.message) {
-    finalMessage.textContent = res.message;
+  console.log('handleUpdate response:', res);
+  if (!finalMessage || !res) return;
+  let message = res.message;
+  if (res.ok && !message) {
+    message = 'RSVP submitted successfully';
+  }
+  if (message) {
+    finalMessage.textContent = message;
+    finalMessage.classList.remove('hidden');
   }
 }
 


### PR DESCRIPTION
## Summary
- Ensure server response for RSVP updates is logged and displayed.
- Add default "RSVP submitted successfully" message when ok response lacks one.

## Testing
- ⚠️ `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b000a45d60832e89b6104fe71606f8