### PR TITLE
Fix RSVP test script to handle nested responses

### DIFF
--- a/assets/js/rsvp-test.js
+++ b/assets/js/rsvp-test.js
@@ -2,23 +2,21 @@
 
 function handleUpdate(res) {
   console.log('handleUpdate response:', res);
-  if (!finalMessage || !res) return;
-  let message = res.message;
-  if (res.ok && !message) {
+  if (!finalMessage) return;
+
+  // Support both flat and nested response shapes (e.g. res.data.message).
+  const payload = res && res.data ? res.data : res;
+  const ok =
+    (res && res.ok) || (res && res.data && res.data.ok);
+
+  let message = payload && payload.message;
+  if (!message && ok) {
     message = 'RSVP submitted successfully';
   }
+
   if (message) {
     finalMessage.textContent = message;
     finalMessage.classList.remove('hidden');
-  console.log(res);
-
-  // Support both flat and nested response shapes (e.g. res.data.message).
-  const ok =
-    (res && res.ok) || (res && res.data && res.data.ok);
-  const payload = res && res.data ? res.data : res;
-
-  if (finalMessage && ok && payload && payload.message) {
-    finalMessage.textContent = payload.message;
   }
 }
 


### PR DESCRIPTION
## Summary
- clean up rsvp-test handler to support nested response formats
- show success message by default when no message provided

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b06bdbf794832ea52201e01435eed0