### PR TITLE
Validate RSVP code format before server request

### DIFF
--- a/assets/js/rsvp-test.js
+++ b/assets/js/rsvp-test.js
@@ -143,7 +143,12 @@ document.addEventListener('DOMContentLoaded', () => {
     const input = document.getElementById('code-input');
     const code = input.value.trim();
     currentCode = code;
-    validateCode(code);
+    if (/^\d{5}$/.test(code)) {
+      codeError.classList.add('hidden');
+      validateCode(code);
+    } else {
+      codeError.classList.remove('hidden');
+    }
   });
 
   document.getElementById('party-no').addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- validate RSVP code format with 5-digit regex before API call
- show error message without network request when code format is invalid

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b07573b304832eb76bb2ad8769c665