### PR TITLE
Handle invalid RSVP party size codes

### DIFF
--- a/assets/js/rsvp-test.js
+++ b/assets/js/rsvp-test.js
@@ -27,9 +27,9 @@ function handleValidate(res) {
     (res && res.ok) || (res && res.data && res.data.ok);
   const payload = res && res.data ? res.data : res;
 
-  const size = Number(payload && payload.party_size);
+  const size = parseInt(payload && payload.partySize, 10);
 
-  if (ok && Number.isInteger(size) && size > 0) {
+  if (ok && !Number.isNaN(size) && size > 0) {
     codeError.classList.add('hidden');
     stepCode.classList.add('hidden');
     stepAttending.classList.remove('hidden');


### PR DESCRIPTION
## Summary
- Parse `partySize` with `parseInt` in RSVP validation
- Display invalid-code error when party size is missing or non-numeric

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68b07599748c832eb529c8cc3356f94a