### PR TITLE
Use fetch for RSVP code validation

### DIFF
--- a/assets/js/rsvp-test.js
+++ b/assets/js/rsvp-test.js
@@ -76,12 +76,14 @@ function validateCode(code) {
   const url =
     apiBase +
     '?action=validate&code=' +
-    encodeURIComponent(code) +
-    '&callback=handleValidate';
-  jsonpRequest(url, 'handleValidate', () => {
-    codeError.textContent = 'Request failed. Please try again.';
-    codeError.classList.remove('hidden');
-  });
+    encodeURIComponent(code);
+  fetch(url, { mode: 'cors' })
+    .then((res) => res.json())
+    .then((data) => handleValidate(data))
+    .catch(() => {
+      codeError.textContent = 'Request failed. Please try again.';
+      codeError.classList.remove('hidden');
+    });
 }
 
 function rsvpNo(code) {


### PR DESCRIPTION
## Summary
- Replace JSONP code validation with CORS-enabled fetch
- Keep RSVP submission requests as existing JSONP

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b07429b418832eba41992b9836049c