### PR TITLE
Guard RSVP test logs with DEBUG flag

### DIFF
--- a/assets/js/rsvp-test.js
+++ b/assets/js/rsvp-test.js
@@ -1,7 +1,9 @@
 // assets/js/rsvp-test.js
 
+const DEBUG = false;
+
 function handleUpdate(res) {
-  console.log('handleUpdate response:', res);
+  if (DEBUG) console.log('handleUpdate response:', res);
   if (!finalMessage) return;
 
   // Support both flat and nested response shapes (e.g. res.data.message).
@@ -21,7 +23,7 @@ function handleUpdate(res) {
 }
 
 function handleValidate(res) {
-  console.log(res);
+  if (DEBUG) console.log(res);
   // Support both flat and nested response shapes.
   const ok =
     (res && res.ok) || (res && res.data && res.data.ok);


### PR DESCRIPTION
## Summary
- Add configurable DEBUG flag in rsvp-test.js
- Wrap console logging in DEBUG checks to disable them in production

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b075aae014832e966f4a95334645a0