### PR TITLE
Differentiate RSVP error states

### DIFF
--- a/assets/js/rsvp-test.js
+++ b/assets/js/rsvp-test.js
@@ -188,7 +188,13 @@ document.addEventListener('DOMContentLoaded', () => {
         else if (meal === 'vegetarian') vegetarian++;
       }
     });
-    if (!valid || num === 0 || num !== chicken + beef + vegetarian) {
+    if (num === 0) {
+      mealError.textContent = 'Please select at least one guest to attend.';
+      mealError.classList.remove('hidden');
+      return;
+    }
+    if (!valid || num !== chicken + beef + vegetarian) {
+      mealError.textContent = 'Every attending guest must choose a meal.';
       mealError.classList.remove('hidden');
       return;
     }

--- a/rsvp-test.html
+++ b/rsvp-test.html
@@ -54,9 +54,7 @@
 
         <form id="step-guests" class="hidden">
           <div id="guest-cards"></div>
-          <div id="meal-error" class="error hidden">
-            Number of meals must equal number of guests attending.
-          </div>
+          <div id="meal-error" class="error hidden"></div>
           <button type="submit">Submit RSVP</button>
         </form>
 


### PR DESCRIPTION
## Summary
- Display specific RSVP error when no guests are selected
- Warn when attending guests are missing meal choices

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b075a54eb8832ea079b9e4ef31572a