### PR TITLE
Use party name in RSVP prompt

### DIFF
--- a/assets/js/rsvp.js
+++ b/assets/js/rsvp.js
@@ -37,19 +37,19 @@ function handleValidate(res) {
     stepCode.classList.add('hidden');
     stepAttending.classList.remove('hidden');
     partySize = size;
-    if (name) {
-      if (welcomeMessage) {
+
+    if (welcomeMessage) {
+      if (name) {
         welcomeMessage.textContent = `We found your record. Welcome, ${name}`;
-        welcomeMessage.classList.remove('hidden');
-      }
-      partyNameMessage.textContent = 'Is your party attending?';
-    } else {
-      if (welcomeMessage) {
+      } else {
         welcomeMessage.textContent = 'We found your record.';
-        welcomeMessage.classList.remove('hidden');
       }
-      partyNameMessage.textContent = 'Is your party attending?';
+      welcomeMessage.classList.remove('hidden');
     }
+
+    partyNameMessage.textContent = name
+      ? `Is ${name}'s party attending?`
+      : 'Is your party attending?';
   } else {
     codeError.classList.remove('hidden');
   }

--- a/rsvp.html
+++ b/rsvp.html
@@ -48,7 +48,7 @@
 
         <div id="step-attending" class="hidden">
           <p id="welcome-message" class="hidden"></p>
-          <p id="party-name-message">Is your party attending?</p>
+          <p id="party-name-message"></p>
           <div class="rsvp-choice">
             <button type="button" id="party-no">No</button>
             <button type="button" id="party-yes">Yes</button>


### PR DESCRIPTION
## Summary
- Personalize RSVP prompt to include party name when available
- Remove default text from RSVP prompt placeholder
- Fall back to generic prompt when party name is missing

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b09a1781b8832eb310651c440fca5f