### PR TITLE
feat: remove guest code validation and update invite text

### DIFF
--- a/assets/js/rsvp.js
+++ b/assets/js/rsvp.js
@@ -186,19 +186,15 @@ document.addEventListener('DOMContentLoaded', () => {
     const input = document.getElementById('code-input');
     const code = input.value.trim();
     currentCode = code;
-    if (/^\d{5}$/.test(code)) {
-      codeError.classList.add('hidden');
-      codeSubmit.disabled = true;
-      if (codeStatus) {
-        codeStatus.textContent = 'Looking up record...';
-        codeStatus.classList.remove('hidden');
-      }
-      validateCode(code).finally(() => {
-        codeSubmit.disabled = false;
-      });
-    } else {
-      codeError.classList.remove('hidden');
+    codeError.classList.add('hidden');
+    codeSubmit.disabled = true;
+    if (codeStatus) {
+      codeStatus.textContent = 'Looking up record...';
+      codeStatus.classList.remove('hidden');
     }
+    validateCode(code).finally(() => {
+      codeSubmit.disabled = false;
+    });
   });
 
   document.getElementById('party-no').addEventListener('click', () => {

--- a/rsvp.html
+++ b/rsvp.html
@@ -31,13 +31,10 @@
       <h1>RSVP</h1>
       <div class="card intro-card" id="rsvpCard">
         <div id="step-code">
-          <label for="code-input">Enter your 5-digit code:</label>
+          <label for="code-input">Enter the "Invite Code" you received with your invitation:</label>
           <input
             type="text"
             id="code-input"
-            pattern="\d{5}"
-            maxlength="5"
-            required
           />
           <button id="code-submit">Submit</button>
           <div id="code-status" class="hidden"></div>


### PR DESCRIPTION
## Summary
- allow any invite code input by removing client-side validation
- update RSVP page to reference the "Invite Code" from the invitation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0f2623e2c832e9966ec3fd92d2e37