### PR TITLE
Increase RSVP timeout to avoid transient error flashes

### DIFF
--- a/assets/js/rsvp.js
+++ b/assets/js/rsvp.js
@@ -103,7 +103,7 @@ window.handleValidate = function handleValidate(res) {
 const apiBase =
   'https://script.google.com/macros/s/AKfycbxWH3YLiS4PGTM8wMGEqZMgrqzAT1DjvmpB6ejmDYhEP5TitSxoVP1A5rHhR-584n7XbA/exec';
 
-function jsonpRequest(url, callbackName, timeout = 5000) {
+function jsonpRequest(url, callbackName, timeout = 15000) {
   return new Promise((resolve, reject) => {
     const script = document.createElement('script');
     const original = window[callbackName];


### PR DESCRIPTION
## Summary
- Increase default JSONP timeout for RSVP flow to 15 seconds to reduce false error messages when responses are slow

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bd030ac180832e856470f542813e4b