### PR TITLE
style: use theme green for countdown text

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -729,11 +729,9 @@ body {
   padding-top: 60px;
   animation: fadeIn var(--t-med) var(--ease);
 }
-.flip-label {
-  color: white;
-}
+.flip-label,
 .separator {
-  color: white;
+  color: var(--emerald-border);
 }
 
 @keyframes fadeIn {


### PR DESCRIPTION
## Summary
- ensure countdown clock labels and separators use theme green for visibility

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c34a2b297c832e8ea02d11224f22e7