### PR TITLE
Set countdown supporting text to white

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -545,7 +545,7 @@ body {
   font-family: var(--font-heading);
   font-size: 2.2rem;
   line-height: 60px;
-  color: var(--emerald-border);
+  color: var(--white);
 }
 
 .flip-group {
@@ -560,7 +560,7 @@ body {
 
 .flip-label {
   margin-top: 4px;
-  color: var(--emerald-border);
+  color: var(--white);
   font-family: var(--font-heading);
   letter-spacing: 0.05em;
 }
@@ -731,7 +731,7 @@ body {
 }
 .flip-label,
 .separator {
-  color: var(--emerald-border);
+  color: var(--white);
 }
 
 @keyframes fadeIn {


### PR DESCRIPTION
## Summary
- Keep flip clock digits in theme green
- Switch countdown labels and separators to white for contrast

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c34cc3d010832e8cb6a8e1d8ffe026