### PR TITLE
Separate countdown styles for index and home pages

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -565,6 +565,17 @@ body {
   letter-spacing: 0.05em;
 }
 
+/* Color variants for countdown */
+.flip-clock.flip-intro .separator,
+.flip-clock.flip-intro .flip-label {
+  color: var(--emerald-border);
+}
+
+.flip-clock.flip-home .separator,
+.flip-clock.flip-home .flip-label {
+  color: var(--white);
+}
+
 /* Size modifiers */
 .flip-clock.flip-small .flip-digit {
   width: 32px;
@@ -729,11 +740,6 @@ body {
   padding-top: 60px;
   animation: fadeIn var(--t-med) var(--ease);
 }
-.flip-label,
-.separator {
-  color: var(--white);
-}
-
 @keyframes fadeIn {
   from {
     opacity: 0;

--- a/home.html
+++ b/home.html
@@ -29,7 +29,7 @@
     <!-- ── Sticky Header & Nav (same on every page!) ── -->
     <div id="site-header"></div>
 
-    <div id="countdown" class="flip-clock flip-large"></div>
+    <div id="countdown" class="flip-clock flip-large flip-home"></div>
     <main class="content-container">
       <h1>Welcome Family & Friends</h1>
       <p>

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
           September 12, 2026&nbsp;•&nbsp;Portola, CA
         </div>
         <!-- ⬇ New countdown ticker -->
-        <div id="countdown" class="flip-clock flip-small"></div>
+        <div id="countdown" class="flip-clock flip-small flip-intro"></div>
       </a>
     </div>
 


### PR DESCRIPTION
## Summary
- Differentiate countdown clock by page
- Show green labels and separators on landing page
- Preserve white countdown styling on home page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c35458a970832e873929963e4aed93