### PR TITLE
Ensure Google Fonts stylesheet preloads on every page

### DIFF
--- a/attire.html
+++ b/attire.html
@@ -12,7 +12,10 @@
       rel="preload"
       as="style"
       href="https://fonts.googleapis.com/css2?family=Cinzel+Decorative:wght@400;700&family=Spectral:wght@400;700&display=swap"
-      onload="this.rel='stylesheet'"
+    />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Cinzel+Decorative:wght@400;700&family=Spectral:wght@400;700&display=swap"
     />
     <noscript>
       <link

--- a/events.html
+++ b/events.html
@@ -12,7 +12,10 @@
       rel="preload"
       as="style"
       href="https://fonts.googleapis.com/css2?family=Cinzel+Decorative:wght@400;700&family=Spectral:wght@400;700&display=swap"
-      onload="this.rel='stylesheet'"
+    />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Cinzel+Decorative:wght@400;700&family=Spectral:wght@400;700&display=swap"
     />
     <noscript>
       <link

--- a/faqs.html
+++ b/faqs.html
@@ -15,7 +15,10 @@
       rel="preload"
       as="style"
       href="https://fonts.googleapis.com/css2?family=Cinzel+Decorative:wght@400;700&family=Spectral:wght@400;700&display=swap"
-      onload="this.rel='stylesheet'"
+    />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Cinzel+Decorative:wght@400;700&family=Spectral:wght@400;700&display=swap"
     />
     <noscript>
       <link

--- a/gallery.html
+++ b/gallery.html
@@ -15,7 +15,10 @@
       rel="preload"
       as="style"
       href="https://fonts.googleapis.com/css2?family=Cinzel+Decorative:wght@400;700&family=Spectral:wght@400;700&display=swap"
-      onload="this.rel='stylesheet'"
+    />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Cinzel+Decorative:wght@400;700&family=Spectral:wght@400;700&display=swap"
     />
     <noscript>
       <link

--- a/home.html
+++ b/home.html
@@ -15,7 +15,10 @@
       rel="preload"
       as="style"
       href="https://fonts.googleapis.com/css2?family=Cinzel+Decorative:wght@400;700&family=Spectral:wght@400;700&display=swap"
-      onload="this.rel='stylesheet'"
+    />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Cinzel+Decorative:wght@400;700&family=Spectral:wght@400;700&display=swap"
     />
     <noscript>
       <link

--- a/index.html
+++ b/index.html
@@ -15,7 +15,10 @@
       rel="preload"
       as="style"
       href="https://fonts.googleapis.com/css2?family=Cinzel+Decorative:wght@400;700&family=Spectral:wght@400;700&display=swap"
-      onload="this.rel='stylesheet'"
+    />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Cinzel+Decorative:wght@400;700&family=Spectral:wght@400;700&display=swap"
     />
     <noscript>
       <link

--- a/our-story.html
+++ b/our-story.html
@@ -15,7 +15,10 @@
       rel="preload"
       as="style"
       href="https://fonts.googleapis.com/css2?family=Cinzel+Decorative:wght@400;700&family=Spectral:wght@400;700&display=swap"
-      onload="this.rel='stylesheet'"
+    />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Cinzel+Decorative:wght@400;700&family=Spectral:wght@400;700&display=swap"
     />
     <noscript>
       <link

--- a/registry.html
+++ b/registry.html
@@ -12,7 +12,10 @@
       rel="preload"
       as="style"
       href="https://fonts.googleapis.com/css2?family=Cinzel+Decorative:wght@400;700&family=Spectral:wght@400;700&display=swap"
-      onload="this.rel='stylesheet'"
+    />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Cinzel+Decorative:wght@400;700&family=Spectral:wght@400;700&display=swap"
     />
     <noscript>
       <link

--- a/rsvp.html
+++ b/rsvp.html
@@ -12,7 +12,10 @@
       rel="preload"
       as="style"
       href="https://fonts.googleapis.com/css2?family=Cinzel+Decorative:wght@400;700&family=Spectral:wght@400;700&display=swap"
-      onload="this.rel='stylesheet'"
+    />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Cinzel+Decorative:wght@400;700&family=Spectral:wght@400;700&display=swap"
     />
     <noscript>
       <link

--- a/travel.html
+++ b/travel.html
@@ -14,7 +14,10 @@
       rel="preload"
       as="style"
       href="https://fonts.googleapis.com/css2?family=Cinzel+Decorative:wght@400;700&family=Spectral:wght@400;700&display=swap"
-      onload="this.rel='stylesheet'"
+    />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Cinzel+Decorative:wght@400;700&family=Spectral:wght@400;700&display=swap"
     />
     <noscript>
       <link

--- a/wedding-party.html
+++ b/wedding-party.html
@@ -12,7 +12,10 @@
       rel="preload"
       as="style"
       href="https://fonts.googleapis.com/css2?family=Cinzel+Decorative:wght@400;700&family=Spectral:wght@400;700&display=swap"
-      onload="this.rel='stylesheet'"
+    />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Cinzel+Decorative:wght@400;700&family=Spectral:wght@400;700&display=swap"
     />
     <noscript>
       <link


### PR DESCRIPTION
## Summary
- preload the shared Google Fonts stylesheet on every HTML page
- add a regular stylesheet link to guarantee the font CSS is applied immediately after the preload fetch completes

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68ccb8b8ebe0832ea2f8da3851b955dc