### PR TITLE
Ensure gallery frame uses white background

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -197,7 +197,7 @@ body.allow-scroll {
   border: 3px solid var(--white);
   border-radius: calc(var(--card-radius) + 12px);
   padding: 2rem;
-  background: rgba(0, 45, 31, 0.85);
+  background: var(--white);
   box-shadow: 0 16px 40px rgba(0, 0, 0, 0.25);
 }
 


### PR DESCRIPTION
## Summary
- switch the gallery frame background to solid white to match the borders used elsewhere

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68ccd46d886c832e8c74cacf1e19e5e2