### PR TITLE
Streamline landing page layout

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -137,33 +137,75 @@ input[type="submit"]:hover {
   background: var(--emerald-hover);
 }
 
-/* video background */
-.background-video {
-  position: fixed;
-  inset: 0;
-  overflow: hidden;
-  z-index: 0;
-  background: var(--bg-emerald-dark) url("assets/video-fallback.jpg")
-    center/cover no-repeat;
+/* Landing layout (index.html) */
+.intro-landing {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 1.5rem;
+  text-align: center;
+  padding: 4rem 1.5rem 5rem;
+  min-height: 100vh;
+  max-width: 560px;
+  margin: 0 auto;
 }
 
-.background-video video {
-  position: absolute;
-  inset: 0;
-  width: 100%;
-  height: 100%;
+.landing-photo {
+  width: 168px;
+  height: 168px;
+  border-radius: 50%;
   object-fit: cover;
-  transition: opacity var(--t-med) var(--ease-med);
-  background: var(--bg-emerald-dark);
+  box-shadow: 0 6px 24px rgba(1, 68, 33, 0.25);
 }
 
-/* overlay */
-.video-overlay {
-  position: fixed;
-  inset: 0;
-  background: var(--emerald-overlay);
-  z-index: 1;
-  pointer-events: none;
+.landing-title {
+  font-family: var(--font-heading);
+  font-size: clamp(2.6rem, 5vw, 3.1rem);
+  letter-spacing: 0.08em;
+  margin: 0;
+  color: var(--emerald-border);
+  text-transform: uppercase;
+}
+
+.landing-date {
+  font-size: 1.3rem;
+  margin: 0;
+  letter-spacing: 0.04em;
+  color: var(--emerald-accent);
+}
+
+.landing-message {
+  font-size: 1.05rem;
+  line-height: 1.65;
+  margin: 0;
+  max-width: 42ch;
+}
+
+.landing-actions {
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+  width: 100%;
+}
+
+.landing-actions .main-btn {
+  min-width: 220px;
+}
+
+@media (max-width: 700px) {
+  .intro-landing {
+    padding: 3rem 1rem 4rem;
+  }
+
+  .landing-photo {
+    width: 128px;
+    height: 128px;
+  }
+
+  .landing-message {
+    font-size: 1rem;
+  }
 }
 
 /* base card styling */
@@ -173,6 +215,13 @@ input[type="submit"]:hover {
   border-radius: var(--card-radius);
   box-shadow: 0 8px 40px rgba(0, 0, 0, 0.12);
   border: 2px solid var(--emerald-border);
+  padding: 3rem 2.5rem 2.5rem;
+  max-width: 460px;
+  width: 90%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
   font-family: var(--font-heading);
   text-decoration: none;
   cursor: pointer;
@@ -181,6 +230,28 @@ input[type="submit"]:hover {
     color var(--t-fast) var(--ease-med),
     transform var(--t-fast) var(--ease-med),
     opacity var(--t-med) var(--ease-med);
+}
+
+.card > * {
+  margin: 0;
+}
+
+.card > *:last-child {
+  margin-bottom: 0;
+}
+
+.card:hover,
+.card:focus {
+  box-shadow: 0 12px 48px rgba(1, 68, 33, 0.18);
+  transform: translateY(-2px) scale(1.02);
+}
+
+@media (max-width: 600px) {
+  .card {
+    padding: 1.75rem 1rem 2.1rem;
+    max-width: 100%;
+    width: 100%;
+  }
 }
 
 /* buttons share the same structure as cards but use the
@@ -222,12 +293,6 @@ input[type="submit"]:hover {
 }
 
 /* fade utility */
-.fade-out {
-  opacity: 0 !important;
-  pointer-events: none;
-  transition: opacity var(--t-med) var(--ease-med);
-}
-
 body.allow-scroll {
   overflow-y: auto;
 }
@@ -685,18 +750,9 @@ body {
     margin: 1.5rem 0 0.75rem;
   }
 
-  /* Optimize intro card for landscape */
+  /* Compact card spacing for landscape */
   .card {
     padding: 1rem 0.5rem;
-  }
-
-  .wedding-names {
-    font-size: 1.8rem;
-  }
-
-  .wedding-date {
-    font-size: 0.9rem;
-    margin-bottom: 1.5rem;
   }
 
   /* Optimize flip clock for landscape */
@@ -854,11 +910,6 @@ body {
 }
 
 /* Color variants for countdown */
-.flip-clock.flip-intro .separator,
-.flip-clock.flip-intro .flip-label {
-  color: var(--emerald-border);
-}
-
 .flip-clock.flip-home .separator,
 .flip-clock.flip-home .flip-label {
   color: var(--white);
@@ -893,124 +944,6 @@ body {
 
 .flip-clock.flip-large .flip-label {
   font-size: 1rem;
-}
-
-
-/* ======================================================
-   A. INTRO‑PAGE RULES (only on index.html)
-   ====================================================== */
-
-/* Scroll‑lock only when <body class="no-scroll"> */
-.no-scroll,
-.no-scroll html {
-  overflow: hidden;
-  height: 100vh;
-}
-
-/* Intro card container */
-.intro-card-container {
-  position: fixed;
-  inset: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 2;
-  opacity: 0;
-  transition: opacity var(--t-med) var(--ease-med);
-  pointer-events: none;
-}
-.intro-card-container.visible {
-  opacity: 1;
-  pointer-events: auto;
-}
-
-/* Card component inside intro */
-.card {
-  background: var(--white);
-  color: #222;
-  border-radius: var(--card-radius);
-  box-shadow: 0 8px 40px rgba(0, 0, 0, 0.12);
-  border: 1.5px solid var(--gray-light);
-  padding: 3rem 2.5rem 2.5rem;
-  max-width: 460px;
-  width: 90%;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  text-decoration: none;
-  cursor: pointer;
-  transition:
-    box-shadow 0.23s,
-    border 0.2s,
-    transform 0.16s,
-    opacity var(--t-med) var(--ease-med);
-}
-.card:hover,
-.card:focus {
-  box-shadow: 0 12px 48px rgba(1, 68, 33, 0.18);
-  border: 2px solid var(--emerald-border);
-  transform: translateY(-2px) scale(1.02);
-}
-
-/* Photo & text in intro card */
-.circle-photo {
-  width: var(--photo-size);
-  height: var(--photo-size);
-  border-radius: 50%;
-  object-fit: cover;
-  border: 4px solid var(--white);
-  box-shadow: 0 2px 10px rgba(1, 68, 33, 0.07);
-  margin-bottom: 1rem;
-}
-.wedding-names {
-  font-family: var(--font-heading);
-  font-size: 2.7rem;
-  font-weight: 600;
-  margin: 0 0 1rem;
-  letter-spacing: 0.07em;
-  color: var(--emerald-border);
-  text-align: center;
-}
-.wedding-date {
-  font-size: 1.18rem;
-  color: var(--emerald-accent);
-  margin-bottom: 2.3rem;
-  letter-spacing: 0.04em;
-  text-align: center;
-}
-
-/* Responsive tweaks for intro */
-@media (max-width: 600px) {
-  .card {
-    padding: 1.4rem 0.5rem;
-    max-width: 98%;
-  }
-  .circle-photo {
-    width: 68px;
-    height: 68px;
-  }
-  .wedding-names {
-    font-size: 2rem;
-  }
-  .wedding-date {
-    font-size: 1rem;
-  }
-  /* Ensure countdown fits within the intro card */
-  #countdown.flip-clock {
-    gap: 2px;
-  }
-  #countdown.flip-clock.flip-small .flip-digit {
-    width: 20px;
-    height: 30px;
-    font-size: 1.2rem;
-  }
-  #countdown.flip-clock.flip-small .separator {
-    font-size: 1.4rem;
-    line-height: 30px;
-  }
-  #countdown.flip-clock.flip-small .flip-label {
-    font-size: 0.7rem;
-  }
 }
 
 
@@ -1938,8 +1871,6 @@ a:focus {
   /* Hide non-essential elements when printing */
   .site-header,
   .main-nav,
-  .background-video,
-  .video-overlay,
   button:not(.main-btn),
   .modal-overlay,
   .lightbox,

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -54,28 +54,7 @@ window.initHeader = initHeader;
 document.addEventListener("DOMContentLoaded", () => {
   initHeader();
 
-  // ── 2) Intro‑card fade‑in + click (only on index.html) ──
-  const introCard = document.getElementById("introCard");
-  if (introCard) {
-    // fade in after 3s
-    setTimeout(() => introCard.classList.add("visible"), 3000);
-
-    const introLink = introCard.querySelector("a.intro-card");
-    if (introLink) {
-      introLink.addEventListener("click", (e) => {
-        e.preventDefault();
-        const url = introLink.getAttribute("href");
-        document
-          .querySelector(".background-video video")
-          ?.classList.add("fade-out");
-        document.querySelector(".video-overlay")?.classList.add("fade-out");
-        introCard.classList.add("fade-out");
-        setTimeout(() => (window.location.href = url), 700);
-      });
-    }
-  }
-
-  // ── 3) Countdown ticker (flip clock) ──
+  // ── Countdown ticker (flip clock) ──
   const countdownEl = document.getElementById("countdown");
   if (countdownEl) {
     try {

--- a/assets/photos.json
+++ b/assets/photos.json
@@ -19,5 +19,13 @@
   "assets/images/gallery/B728140D-6A80-49E3-BC60-1AAF0C8A0189_1_105_c.jpeg",
   "assets/images/gallery/D77ED636-F2FC-44B0-B4D6-357F0413BD8A.jpeg",
   "assets/images/gallery/E9C7E87A-291A-492E-AC35-F08C083D5CD6.jpeg",
-  "assets/images/gallery/F48B7F5E-CC57-4662-A230-5914A503048B_1_105_c.jpeg"
+  "assets/images/gallery/F48B7F5E-CC57-4662-A230-5914A503048B_1_105_c.jpeg",
+  "assets/images/gallery/top_left.jpeg",
+  "assets/images/gallery/top_mid.jpeg",
+  "assets/images/gallery/top_right.jpeg",
+  "assets/images/gallery/bot_left.jpeg",
+  "assets/images/gallery/bot_mid.jpeg",
+  "assets/images/gallery/bot_right.jpeg",
+  "assets/images/gallery/left.jpeg",
+  "assets/images/gallery/right.jpeg"
 ]

--- a/index.html
+++ b/index.html
@@ -11,46 +11,32 @@
       content="default-src 'self'; script-src 'self' 'unsafe-inline' https://script.google.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; media-src 'self'; connect-src 'self' https://script.google.com; frame-src 'none'; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;"
     />
     <meta name="description" content="Christopher & Lorraine's Wedding - September 12, 2026 in Portola, CA" />
-    <title>Home</title>
+    <title>Welcome</title>
     <link rel="icon" type="image/png" href="assets/images/favicon.png" />
     <link rel="stylesheet" href="assets/css/main.css" />
   </head>
-  <body class="no-scroll">
-    <!-- Video background with poster fallback -->
-    <div class="background-video">
-      <video autoplay muted loop playsinline poster="assets/video-fallback.jpg">
-        <source src="assets/video.mp4" type="video/mp4" />
-        <img
-          src="assets/video-fallback.jpg"
-          alt="Christopher & Lorraine"
-          style="width: 100%; height: 100%; object-fit: cover"
-          loading="lazy"
-        />
-      </video>
-    </div>
+  <body class="allow-scroll">
+    <a href="#main-content" class="skip-link">Skip to main content</a>
 
-    <!-- Dim overlay -->
-    <div class="video-overlay"></div>
+    <main id="main-content" class="intro-landing">
+      <img
+        src="assets/images/index.jpeg"
+        alt="Christopher & Lorraine"
+        class="landing-photo"
+        loading="lazy"
+      />
+      <h1 class="landing-title">Lorraine &amp; Christopher</h1>
+      <p class="landing-date">September 12, 2026&nbsp;•&nbsp;Portola, CA</p>
+      <div id="countdown" class="flip-clock flip-small" aria-live="polite"></div>
+      <p class="landing-message">
+        Welcome to Becoming Cummings! Explore the details, browse the gallery, and RSVP so we can celebrate together in
+        Portola.
+      </p>
+      <div class="landing-actions">
+        <a href="home.html" class="main-btn">Enter the Site</a>
+      </div>
+    </main>
 
-    <!-- Intro card (fades in) -->
-    <div class="intro-card-container" id="introCard">
-      <a href="home.html" class="card intro-card" tabindex="0">
-        <img
-          src="assets/images/index.jpeg"
-          alt="Christopher & Lorraine"
-          class="circle-photo"
-          loading="lazy"
-        />
-        <h1 class="wedding-names">Lorraine<br />&amp;<br />Christopher</h1>
-        <div class="wedding-date">
-          September 12, 2026&nbsp;•&nbsp;Portola, CA
-        </div>
-        <!-- ⬇ New countdown ticker -->
-        <div id="countdown" class="flip-clock flip-small flip-intro"></div>
-      </a>
-    </div>
-
-    <script src="assets/js/header.js"></script>
     <script src="assets/js/script.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- replace the video-based splash page with a static welcome layout centered around a single container and no navigation header
- add the newly uploaded gallery photos to `assets/photos.json`
- drop the intro video specific scripting and styles that are no longer needed

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da0767ffa8832e994f5346e128abb2