### PR TITLE
Improve countdown readability on landing page

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -908,6 +908,13 @@ body {
   letter-spacing: 0.05em;
 }
 
+/* Improve index countdown contrast */
+#countdown.flip-clock .separator,
+#countdown.flip-clock .flip-label {
+  color: var(--emerald-accent);
+  text-shadow: 0 0 6px rgba(0, 0, 0, 0.35);
+}
+
 /* Color variants for countdown */
 .flip-clock.flip-home .separator,
 .flip-clock.flip-home .flip-label {


### PR DESCRIPTION
## Summary
- update the landing page countdown separators and labels to use the emerald accent color
- add a subtle text shadow so the semicolons and time unit labels remain legible over the background

## Testing
- not run (static assets only)


------
https://chatgpt.com/codex/tasks/task_e_68da15895d70832eaf486dd912ff0c42