### PR TITLE
Remove countdown section from home page

### DIFF
--- a/home.html
+++ b/home.html
@@ -20,7 +20,6 @@
     <!-- ── Sticky Header & Nav (same on every page!) ── -->
     <div id="site-header"></div>
 
-    <div id="countdown" class="flip-clock flip-large flip-home"></div>
     <main id="main-content" class="content-container">
       <h1>Welcome Family & Friends</h1>
       <p>


### PR DESCRIPTION
## Summary
- remove the countdown element from the home page so the timer no longer renders

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68da1d914d68832eaf996d3099ef2fda