### PR TITLE
Remove landing message text from index

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,10 +29,6 @@
         <h1 class="landing-title">Lorraine &amp; Christopher</h1>
         <p class="landing-date">September 12, 2026&nbsp;•&nbsp;Portola, CA</p>
         <div id="countdown" class="flip-clock flip-small" aria-live="polite"></div>
-        <p class="landing-message">
-          Welcome to Becoming Cummings! Explore the details, browse the gallery, and RSVP so we can celebrate together in
-          Portola.
-        </p>
         <div class="landing-actions">
           <a href="home.html" class="main-btn">Enter the Site</a>
         </div>


### PR DESCRIPTION
## Summary
- remove the introductory landing message from the index page so only the enter button remains beneath the countdown

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dacd7b3414832eaab97849b5563b05