### PR TITLE
Separate landing date and location lines

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,10 @@
           loading="lazy"
         />
         <h1 class="landing-title">Lorraine &amp; Christopher</h1>
-        <p class="landing-date">September 12, 2026&nbsp;•&nbsp;Portola, CA</p>
+        <p class="landing-date">
+          <span class="landing-date__date">September 12, 2026</span><br />
+          <span class="landing-date__location">Portola, CA</span>
+        </p>
         <div id="countdown" class="flip-clock flip-small" aria-live="polite"></div>
         <div class="landing-actions">
           <a href="home.html" class="main-btn">Enter the Site</a>


### PR DESCRIPTION
## Summary
- update the landing date markup on the index page so the wedding date and location render on separate lines

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68dc23cbea48832e8c2c6305ce24a635