### PR TITLE
Add wedding party bios and rename member

### DIFF
--- a/wedding-party.html
+++ b/wedding-party.html
@@ -30,7 +30,7 @@
           aria-labelledby="member-1-name"
           data-name="Cherylynn Jugueta"
           data-role="Maid of Honor"
-          data-bio="Bio coming soon."
+          data-bio="Cherylynn has been Lorraine's confidante since middle school and keeps the planning on track with her calm energy."
           data-img="assets/images/attire.png"
         >
           <img
@@ -46,7 +46,7 @@
           class="party-card"
           data-name="Karl Arias"
           data-role="Best Man"
-          data-bio="Bio coming soon."
+          data-bio="Karl has stood by Christopher since their college days and is always ready with a heartfelt toast."
           data-img="assets/images/attire.png"
         >
           <img src="assets/images/attire.png" alt="Karl Arias" loading="lazy" />
@@ -58,7 +58,7 @@
           class="party-card"
           data-name="Gwen Galano"
           data-role="Bridesmaid"
-          data-bio="Bio coming soon."
+          data-bio="Gwen brings contagious laughter from the bride's hometown crew and can turn any moment into a celebration."
           data-img="assets/images/attire.png"
         >
           <img
@@ -74,7 +74,7 @@
           class="party-card"
           data-name="Paul Ditimi"
           data-role="Best Man"
-          data-bio="Bio coming soon."
+          data-bio="Paul is Christopher's cousin and the go-to organizer for every group adventure."
           data-img="assets/images/attire.png"
         >
           <img src="assets/images/attire.png" alt="Paul Ditimi" loading="lazy" />
@@ -86,7 +86,7 @@
           class="party-card"
           data-name="Ariana Ashly Galano"
           data-role="Bridesmaid"
-          data-bio="Bio coming soon."
+          data-bio="Ariana grew up with Lorraine and loves cheering on every milestone with creative surprises."
           data-img="assets/images/attire.png"
         >
           <img
@@ -102,7 +102,7 @@
           class="party-card"
           data-name="Ishmael Brown"
           data-role="Groomsman"
-          data-bio="Bio coming soon."
+          data-bio="Ishmael met Christopher through work and quickly became the weekend barbecue captain."
           data-img="assets/images/attire.png"
         >
           <img
@@ -118,7 +118,7 @@
           class="party-card"
           data-name="Lorylen Bucio"
           data-role="Bridesmaid"
-          data-bio="Bio coming soon."
+          data-bio="Lorylen is Lorraine's sorority sister and creative partner in every DIY project."
           data-img="assets/images/attire.png"
         >
           <img
@@ -134,7 +134,7 @@
           class="party-card"
           data-name="Adam Rua"
           data-role="Groomsman"
-          data-bio="Bio coming soon."
+          data-bio="Adam is Christopher's childhood friend and always the first to hit the dance floor."
           data-img="assets/images/attire.png"
         >
           <img src="assets/images/attire.png" alt="Adam Rua" loading="lazy" />
@@ -146,7 +146,7 @@
           class="party-card"
           data-name="Sunshine Arias"
           data-role="Bridesmaid"
-          data-bio="Bio coming soon."
+          data-bio="Sunshine is Karl's sister and a ray of positivity in every room."
           data-img="assets/images/attire.png"
         >
           <img
@@ -160,17 +160,17 @@
 
         <div
           class="party-card"
-          data-name="Dexter Wright"
+          data-name="Ariel Castillo"
           data-role="Groomsman"
-          data-bio="Bio coming soon."
+          data-bio="Ariel Castillo is Christopher's longtime roommate and renowned for his late-night pep talks."
           data-img="assets/images/attire.png"
         >
           <img
             src="assets/images/attire.png"
-            alt="Dexter Wright"
+            alt="Ariel Castillo"
             loading="lazy"
           />
-          <h2>Dexter Wright</h2>
+          <h2>Ariel Castillo</h2>
           <p class="role">Groomsman</p>
         </div>
 


### PR DESCRIPTION
## Summary
- add placeholder bios for each member of the wedding party so the modal shows richer text
- rename the Dexter Wright card to Ariel Castillo and update related attributes

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68e4544cc578832eb6d60d8b64b3a7ea