### PR TITLE
Show party bios on image click and resize portraits

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1811,10 +1811,13 @@ body {
   box-shadow: 0 8px 30px rgba(0, 0, 0, 0.12);
 }
 .party-card img {
-  width: 100%;
+  width: 70%;
+  max-width: 220px;
+  margin: 0 auto 0.75rem;
+  display: block;
   border-radius: 50%;
   object-fit: cover;
-  margin-bottom: 0.75rem;
+  cursor: pointer;
 }
 .party-card h2 {
   margin: 0.5rem 0 0.2rem;
@@ -1826,6 +1829,12 @@ body {
   margin: 0;
   font-size: 1rem;
   color: var(--emerald-accent);
+}
+.party-card .bio {
+  margin: 0.75rem 0 0;
+  font-size: 0.95rem;
+  line-height: 1.5;
+  color: #333;
 }
 
 /* Modal overlay */

--- a/assets/js/party.js
+++ b/assets/js/party.js
@@ -12,7 +12,33 @@ document.addEventListener("DOMContentLoaded", () => {
   const close = modal.querySelector(".modal-close");
 
   cards.forEach((card) => {
-    card.addEventListener("click", () => {
+    const imgEl = card.querySelector("img");
+    const bioText = card.dataset.bio;
+    let cardBioEl = card.querySelector(".bio");
+
+    if (bioText && !cardBioEl) {
+      cardBioEl = document.createElement("p");
+      cardBioEl.className = "bio";
+      cardBioEl.hidden = true;
+      card.appendChild(cardBioEl);
+    }
+
+    if (imgEl && cardBioEl) {
+      imgEl.addEventListener("click", (event) => {
+        event.stopPropagation();
+        if (cardBioEl.hidden) {
+          cardBioEl.textContent = bioText;
+          cardBioEl.hidden = false;
+        } else {
+          cardBioEl.hidden = true;
+        }
+      });
+    }
+
+    card.addEventListener("click", (event) => {
+      if (event.target === imgEl && cardBioEl) {
+        return;
+      }
       img.src = card.dataset.img;
       img.alt = card.dataset.name;
       nameEl.textContent = card.dataset.name;

--- a/wedding-party.html
+++ b/wedding-party.html
@@ -46,7 +46,7 @@
           class="party-card"
           data-name="Karl Arias"
           data-role="Best Man"
-          data-bio="Karl has stood by Christopher since their college days and is always ready with a heartfelt toast."
+          data-bio="Chris met Karl in 7th grade and they have been brothers ever since."
           data-img="assets/images/attire.png"
         >
           <img src="assets/images/attire.png" alt="Karl Arias" loading="lazy" />


### PR DESCRIPTION
## Summary
- reveal each wedding party member's bio within the card when their portrait is clicked while keeping the modal behavior on other clicks
- reduce the default portrait size so the grid layout feels more balanced on load

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68e464b1207c832e9488919a0dcef866