### PR TITLE
Adjust RSVP input sanitization to keep ampersands visible

### DIFF
--- a/assets/js/rsvp.js
+++ b/assets/js/rsvp.js
@@ -1,15 +1,12 @@
 // Utility function to sanitize text input
+// Strips control characters and trims whitespace so it can be safely
+// inserted into the DOM via textContent without mutating visible characters
+// such as ampersands.
 function sanitizeInput(input) {
   if (typeof input !== 'string') return '';
-  return input.trim().replace(/[<>"']/g, function(match) {
-    const htmlEscapes = {
-      '<': '&lt;',
-      '>': '&gt;',
-      '"': '&quot;',
-      "'": '&#39;'
-    };
-    return htmlEscapes[match];
-  });
+  return input
+    .replace(/[\u0000-\u001F\u007F]/g, '')
+    .trim();
 }
 
 // Enhanced validation function


### PR DESCRIPTION
## Summary
- update RSVP sanitize helper to strip control characters without HTML-encoding ampersands or quotes
- document reliance on textContent so visible characters render as entered

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e46f2d268c832e90ea35229611b3cd