### PR TITLE
Enhance wedding party modal presentation

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1856,32 +1856,45 @@ body {
 .modal-content {
   background: var(--white);
   border-radius: var(--card-radius);
-  max-width: 500px;
-  width: 90%;
-  padding: 1.5rem;
+  max-width: 460px;
+  width: min(92%, 460px);
+  padding: 1.75rem;
   position: relative;
-  text-align: center;
+  text-align: left;
   box-shadow: 0 8px 40px rgba(0, 0, 0, 0.15);
 }
+.modal-profile {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+  flex-wrap: wrap;
+}
 .modal-content img {
-  width: 100%;
-  max-height: 300px;
+  width: 136px;
+  height: 136px;
   object-fit: cover;
-  border-radius: var(--card-radius);
-  margin-bottom: 1rem;
+  border-radius: 22px;
+  flex-shrink: 0;
+}
+.modal-details {
+  flex: 1;
+  min-width: 180px;
 }
 .modal-content h2 {
-  margin: 0.5rem 0;
+  margin: 0 0 0.35rem;
   font-family: var(--font-heading);
   color: var(--emerald-border);
+  font-size: 1.4rem;
 }
 .modal-content .role {
   color: var(--emerald-accent);
-  margin-bottom: 1rem;
+  margin: 0 0 0.75rem;
+  font-weight: 600;
 }
 .modal-content p {
-  line-height: 1.5;
-  margin-bottom: 1rem;
+  line-height: 1.6;
+  margin: 0;
+  color: #333;
 }
 
 /* Close button */
@@ -1908,10 +1921,11 @@ body {
     font-size: 1rem;
   }
   .modal-content {
-    padding: 1rem;
+    padding: 1.25rem;
   }
   .modal-content img {
-    max-height: 200px;
+    width: 112px;
+    height: 112px;
   }
 }
 

--- a/assets/js/party.js
+++ b/assets/js/party.js
@@ -13,11 +13,16 @@ document.addEventListener("DOMContentLoaded", () => {
 
   cards.forEach((card) => {
     card.addEventListener("click", () => {
-      img.src = card.dataset.img;
-      img.alt = card.dataset.name;
-      nameEl.textContent = card.dataset.name;
-      roleEl.textContent = card.dataset.role;
-      bioEl.textContent = card.dataset.bio;
+      const imgSrc = card.dataset.img || "assets/images/attire.png";
+      const name = card.dataset.name || "Wedding Party Member";
+      const role = card.dataset.role || "Celebrating with us";
+      const bio = card.dataset.bio || "More details about this member will be shared soon.";
+
+      img.src = imgSrc;
+      img.alt = name;
+      nameEl.textContent = name;
+      roleEl.textContent = role;
+      bioEl.textContent = bio;
       modal.classList.remove("hidden");
     });
   });

--- a/wedding-party.html
+++ b/wedding-party.html
@@ -179,7 +179,7 @@
     </main>
 
     <!-- ── Modal Lightbox ── -->
-    <div id="partyModal" class="modal-overlay hidden" role="dialog" aria-modal="true" aria-labelledby="modalName">
+    <div id="partyModal" class="modal-overlay hidden" role="dialog" aria-modal="true" aria-labelledby="modalName" aria-describedby="modalBio">
       <div class="modal-content">
         <button class="modal-close" aria-label="Close">&times;</button>
         <div class="modal-profile">

--- a/wedding-party.html
+++ b/wedding-party.html
@@ -179,13 +179,17 @@
     </main>
 
     <!-- ── Modal Lightbox ── -->
-    <div id="partyModal" class="modal-overlay hidden">
+    <div id="partyModal" class="modal-overlay hidden" role="dialog" aria-modal="true" aria-labelledby="modalName">
       <div class="modal-content">
         <button class="modal-close" aria-label="Close">&times;</button>
-        <img src="" alt="" id="modalImg" loading="lazy" />
-        <h2 id="modalName"></h2>
-        <p class="role" id="modalRole"></p>
-        <p id="modalBio"></p>
+        <div class="modal-profile">
+          <img src="" alt="" id="modalImg" loading="lazy" />
+          <div class="modal-details">
+            <h2 id="modalName"></h2>
+            <p class="role" id="modalRole"></p>
+            <p id="modalBio"></p>
+          </div>
+        </div>
       </div>
     </div>
 


### PR DESCRIPTION
## Summary
- restyle the wedding party modal with a compact profile layout that keeps the portrait smaller and text focused
- ensure the overlay always shows fallback copy so dummy text appears when details are missing

## Testing
- Not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e471d7ce04832e94648e2d4baf182b