### PR TITLE
Add line breaks to landing page headline

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,11 @@
           style="object-position: center 20%;"
           loading="lazy"
         />
-        <h1 class="landing-title">Lorraine &amp; Christopher</h1>
+        <h1 class="landing-title">
+          Lorraine<br />
+          &amp;<br />
+          Christopher
+        </h1>
         <p class="landing-date">
           <span class="landing-date__date">September 12, 2026</span><br />
           <span class="landing-date__location">Portola, CA</span>


### PR DESCRIPTION
## Summary
- insert line breaks around the ampersand in the landing page title so each name and symbol appears on its own line

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e53754bec8832ebc99734d1211b541