### PR TITLE
Update Travel page alternatives copy and remove rides note

### DIFF
--- a/travel.html
+++ b/travel.html
@@ -63,7 +63,7 @@
           <span class="tag">Alternatives</span>
           <h3>Nearby lodging options</h3>
           <p>
-            Please book quickly—rooms in the area fill fast. We are currently working on wedding blocks at the properties below and will update this page as information changes.
+            If you’d like to review more places to stay, there are several nearby options worth checking out.
           </p>
           <ul>
             <li>
@@ -73,9 +73,6 @@
               <a href="https://www.plumaspinesgolf.com" target="_blank" rel="noopener noreferrer">Plumas Pines Golf Course</a>
             </li>
           </ul>
-          <p class="note">
-            We’ll arrange rides as necessary for guests staying offsite.
-          </p>
         </article>
         <article class="travel-card">
           <span class="tag">Airport</span>


### PR DESCRIPTION
### Motivation
- Clarify lodging messaging by removing references to wedding blocks and hotel-arranged rides so guests see neutral alternatives to review.

### Description
- Updated `travel.html` to replace the Alternatives paragraph with a neutral line about nearby lodging and removed the `<p class="note">We’ll arrange rides as necessary for guests staying offsite.</p>`; no skills were used because this is a small copy edit.

### Testing
- Verified the change by inspecting `travel.html`, serving the site with `python3 -m http.server --directory /workspace/wedding-site 4173`, capturing a screenshot with Playwright, and committing the update successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6342d2658832bbdca8a9792032c6d)