### PR TITLE
Mark RSVPs closed: replace interactive flow with static message, tighten CSP, and add styles

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -2883,3 +2883,11 @@ a:focus {
     transition-duration: 0.01ms !important;
   }
 }
+
+.rsvp-closed-card {
+  text-align: center;
+}
+
+.rsvp-closed-card .main-btn {
+  margin-top: 0.75rem;
+}

--- a/home.html
+++ b/home.html
@@ -38,10 +38,10 @@
       </div>
       <div class="feature-grid">
         <article class="feature-card">
-          <span class="pill">RSVP</span>
-          <h3>Reserve your seat</h3>
-          <p>Please confirm your attendance here so we can reserve your seat, plan accordingly, and celebrate with you all weekend</p>
-          <a href="rsvp.html" class="subtle-link">Complete your RSVP →</a>
+          <span class="pill">RSVPs Closed</span>
+          <h3>Online RSVPs are closed</h3>
+          <p>If you still need to update your RSVP, please contact Chris or Lorraine directly.</p>
+          <a href="rsvp.html" class="subtle-link">Read the RSVP update →</a>
         </article>
         <article class="feature-card">
           <span class="pill">Weekend</span>

--- a/rsvp.html
+++ b/rsvp.html
@@ -8,10 +8,10 @@
     <meta http-equiv="Expires" content="0" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self' https://script.google.com https://script.googleusercontent.com; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; media-src 'self'; connect-src 'self' https://script.google.com https://script.googleusercontent.com; frame-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self' https://script.google.com https://script.googleusercontent.com; upgrade-insecure-requests;"
+      content="default-src 'self'; script-src 'self'; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; media-src 'self'; connect-src 'self'; frame-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;"
     />
-    <meta name="description" content="RSVP for Christopher & Lorraine's Wedding - September 12, 2026" />
-    <title>RSVP</title>
+    <meta name="description" content="RSVPs are closed for Christopher & Lorraine's Wedding - September 12, 2026" />
+    <title>RSVP Closed</title>
     <link rel="icon" href="assets/images/favicon.png?v=20240905" type="image/png" />
 
     <link rel="stylesheet" href="assets/css/main.css?v=20240905" />
@@ -25,116 +25,23 @@
     <main id="main-content" class="content-container">
       <div class="page-hero">
         <p class="eyebrow">September 12, 2026 · Portola, CA</p>
-        <h1>RSVP</h1>
+        <h1>RSVPs Are Closed</h1>
         <p class="lede">
-          Let us know you’re joining so we can prepare every seat, toast, and welcome gift with care.
+          Online RSVPs are now closed so we can finalize our plans for the celebration.
         </p>
       </div>
-      <div class="card intro-card" id="rsvpCard">
-        <div id="step-code">
-          <form id="code-form" novalidate>
-            <label for="code-input"
-              >Enter the "Invite Code" you received with your invitation:</label
-            >
-            <p class="code-help" id="code-help">
-              <small
-                ><em
-                  >Your invite code can be found on the back of the box your
-                  invitation was in.</em
-                ></small
-              >
-            </p>
-            <input
-              type="text"
-              id="code-input"
-              required
-              pattern="[-A-Za-z0-9]{3,20}"
-              autocomplete="off"
-              maxlength="20"
-              minlength="3"
-              title="Enter your invite code (3-20 characters, letters, numbers, and hyphens only)"
-              aria-describedby="code-help"
-            />
-            <button id="code-submit" type="submit">Submit</button>
-          </form>
-
-          <!-- Inline expandable help for locating the invite code -->
-          <div class="invite-help" aria-hidden="false">
-            <details>
-              <summary id="invite-code-help-summary">Where do I find my invite code?</summary>
-              <p>
-                The invite code is printed on the back of the box the invitation was recieved in. 
-                If you are unable to find please reach out to Lorraine or Chris.
-              </p>
-
-              <figure>
-                <img src="assets/images/IMG_2405.jpeg" alt="Back of invitation showing where invite code is printed">
-                <figcaption>Please look at the bottom left corner of your invitation box.</figcaption>
-              </figure>
-
-              <figure>
-                <img src="assets/images/invite_front.jpeg" alt="Close-up of invite card showing the invite code">
-                <figcaption>For reference, this is the front of the box.</figcaption>
-              </figure>
-            </details>
-          </div>
-
-          <div
-            id="code-status"
-            class="hidden"
-            role="status"
-            aria-live="polite"
-            hidden
-          ></div>
-          <div id="code-error" class="error hidden" role="alert" hidden>
-            Incorrect code. Please try again.
-          </div>
-        </div>
-
-        <div id="step-attending" class="hidden" hidden>
-          <p id="welcome-message" class="hidden" hidden></p>
-          <p id="party-name-message"></p>
-          <div class="rsvp-choice">
-            <button type="button" id="party-yes">Yes</button>
-            <button type="button" id="party-no">No</button>
-          </div>
-        </div>
-
-        <form id="step-guests" class="hidden" novalidate hidden>
-          <div class="name-edit-controls">
-            <button
-              type="button"
-              id="name-edit-toggle"
-              class="name-edit-toggle"
-              aria-pressed="false"
-              aria-controls="guest-cards"
-            >
-              Edit names
-            </button>
-            <p id="name-edit-note" class="hidden" hidden>
-              Use this to correct spelling or fill in a missing guest name. Contact Chris or Lorraine for any other
-              changes.
-            </p>
-            <p id="name-edit-error" class="error hidden" role="alert" hidden></p>
-          </div>
-          <div id="guest-cards"></div>
-          <div id="meal-error" class="error hidden" role="alert" hidden></div>
-          <button type="submit">Submit RSVP</button>
-        </form>
-
-        <div
-          id="final-message"
-          class="hidden"
-          role="status"
-          aria-live="polite"
-          hidden
-        ></div>
+      <div class="card intro-card rsvp-closed-card" id="rsvpCard">
+        <p>
+          If you still need to update your RSVP or have a question about your attendance, please contact
+          Chris or Lorraine directly.
+        </p>
+        <p>Thank you for understanding—we can’t wait to celebrate with you.</p>
+        <a href="home.html" class="main-btn main-btn--ghost">Return Home</a>
       </div>
     </main>
 
     <!-- site-wide behaviors -->
     <script src="assets/js/header.js?v=20240905"></script>
     <script src="assets/js/script.js?v=20240905"></script>
-    <script src="assets/js/rsvp.js?v=20240905"></script>
   </body>
 </html>


### PR DESCRIPTION
### Motivation

- The RSVP period has ended, so the interactive RSVP flow should be removed and pages updated to reflect that status.
- Reduce external script/cross-origin requirements for the RSVP page by tightening the Content Security Policy.

### Description

- Replace the interactive form and multi-step RSVP UI in `rsvp.html` with a static closed-message card, update the page `title`, `meta` description, `h1`, and lede copy, and remove the `assets/js/rsvp.js` include.
- Tighten the `Content-Security-Policy` in `rsvp.html` by removing external `script-src`, `connect-src`, and `form-action` hosts previously allowed (e.g. `script.google.com`).
- Update the RSVP feature card on `home.html` to show "RSVPs Closed" and point users to the updated `rsvp.html` message link.
- Add `.rsvp-closed-card` styles to `assets/css/main.css` to center content and add spacing for the `.main-btn` inside the closed card.

### Testing

- Served the site locally and opened `rsvp.html` and `home.html` to verify the closed messaging and navigation work as expected with no interactive RSVP UI present.
- Confirmed there are no JavaScript console errors after removing `assets/js/rsvp.js` and that the updated `rsvp.html` loads under the tightened CSP.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09e926c63c832ba127bc6b73646c41)